### PR TITLE
Daniel/touchups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ NYT_API_KEY=your_nyt_api_key_here
 NEWS_API_KEY=your_newsapi_key_here
 NEWS_API_URL=https://newsapi.org/v2/everything
 
-# Generic/Current API (optional)
-CURRENT_API=
-CURRENT_URL=
+# Current API
+# Get key at https://currentsapi.services/en
+CURRENT_API=your_current_api_key_here
+CURRENT_URL=https://api.currentsapi.services/v1/search

--- a/webscraper/README.md
+++ b/webscraper/README.md
@@ -62,6 +62,7 @@ Main entry point. Configure the run at the top of the file:
 | `END` | End date in ISO 8601 format |
 | `API` | Adapter to use — any key from `ADAPTERS` (e.g. `"nyt"`) |
 | `MAX_PAGES` | Number of pages to fetch (1 page = 10 articles). A 13-second sleep is inserted between pages to comply with the NYT rate limit of 5 requests/minute. |
+| `DOMAIN` | Comma separated string of news domains to filter the search for. (e.g., `"foxnews.com, bbc.co.uk"`)|
 
 **What it does:**
 1. Instantiates the selected adapter and fetches articles across `MAX_PAGES` pages
@@ -111,6 +112,10 @@ Results are saved to `<repo_root>/data/{API}_articles.json` as a JSON array. The
 Copy `.env.example` from the repo root to `.env` and fill in your keys:
 
 ```env
-NYT_API_KEY=your_nyt_api_key_here
-NEWS_API_KEY=your_newsapi_key_here
-NEWS_API_URL=https://newsapi.org/v2/everything
+CURRENT_API = "your_current_api_key_here"
+CURRENT_URL = "https://api.currentsapi.services/v1/search"
+
+NEWS_API_KEY = "your_news_api_key_here"
+NEWS_API_URL = "https://newsapi.org/v2/everything"
+
+NYT_API_KEY = "your_nyt_api_key_here"

--- a/webscraper/apis.py
+++ b/webscraper/apis.py
@@ -31,7 +31,7 @@ def get_meta_description(url):
 # ---------------------------------------------------------------------------
 
 class CurrentAPIAdapter:
-    def fetch(self, query, start, end, domain="foxnews.com"):
+    def fetch(self, query, start, end, **kwargs):
         res = requests.get(
             current_url,
             params={
@@ -41,7 +41,7 @@ class CurrentAPIAdapter:
                 "start_date": start,
                 "end_date": end,
                 "apiKey": current_api,
-                "domain": domain,
+                "domain": kwargs.get("domain", ""),
             },
         )
         res.raise_for_status()
@@ -102,7 +102,7 @@ class NYTAdapter:
 
 
 class NewsAPIAdapter:
-    def fetch(self, query, start, end, domain=None):
+    def fetch(self, query, start, end, **kwargs):
         params = {
             "q": query,
             "from": start,
@@ -113,8 +113,8 @@ class NewsAPIAdapter:
             "apiKey": news_api_key,
         }
 
-        if domain:
-            params["domains"] = domain
+        if kwargs.get("domain", ""):
+            params["domains"] = kwargs.get("domain", "")
 
         res = requests.get(news_api_url, params=params, timeout=15)
         res.raise_for_status()

--- a/webscraper/scrape.py
+++ b/webscraper/scrape.py
@@ -6,8 +6,9 @@ from apis import ADAPTERS, get_meta_description
 QUERY     = "Trump Pope Leo"
 START     = "2026-04-12T00:00:00Z"
 END       = "2026-04-19T00:00:00Z"
-API       = "nyt"   # any key from ADAPTERS in apis.py
+API       = "current"   # any key from ADAPTERS in apis.py. One of "current", "nytimes", "newsapi"
 MAX_PAGES = 1       # 1 page = 10 articles; NYT rate limit: 5 req/min
+DOMAIN = ""         # Specify a domain like foxnews.com, or bbc.co.uk. Leave as empty string for no specific domain.
 OVERWRITE = False   # True: replace existing articles with freshly fetched data
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -33,7 +34,7 @@ def main():
     fetched = []
 
     for page in range(MAX_PAGES):
-        fetched.extend(adapter.fetch(QUERY, START, END, page=page))
+        fetched.extend(adapter.fetch(QUERY, START, END, page=page, domain=DOMAIN))
         if page < MAX_PAGES - 1:
             time.sleep(13)  # stay under 5 requests/minute (NYT limit)
 

--- a/webscraper/scrape.py
+++ b/webscraper/scrape.py
@@ -6,9 +6,9 @@ from apis import ADAPTERS, get_meta_description
 QUERY     = "Trump Pope Leo"
 START     = "2026-04-12T00:00:00Z"
 END       = "2026-04-19T00:00:00Z"
-API       = "current"   # any key from ADAPTERS in apis.py. One of "current", "nytimes", "newsapi"
+API       = "nyt"   # any key from ADAPTERS in apis.py. One of "current", "nyt", "newsapi"
 MAX_PAGES = 1       # 1 page = 10 articles; NYT rate limit: 5 req/min
-DOMAIN = ""         # Specify a domain like foxnews.com, or bbc.co.uk. Leave as empty string for no specific domain.
+DOMAIN = "foxnews.com, bbc.co.uk"         # Specify domains as comma separated string 'foxnews.com, bbc.co.uk'. Leave empty string for no specific domain.
 OVERWRITE = False   # True: replace existing articles with freshly fetched data
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")


### PR DESCRIPTION
Updated support for domain-based filtering.

Clarified instructions in comments and webscraper/readme.md

Set default search domains for newsapi and currentapi to foxnews.com and bbc.co.uk to filter out junk news sources.