### PR TITLE
Add news comparison demo feature

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -256,6 +256,23 @@ function renderLLM() {
   });
 }
 
+// Hardcode to show comparison results when "Run Comparison" is clicked, since we don't have real LLM outputs in this prototype.
+const runCompareBtn = document.getElementById("run-compare-btn");
+const comparisonResults = document.getElementById("comparison-results");
+if (runCompareBtn && comparisonResults) {
+  runCompareBtn.addEventListener("click", () => {
+    comparisonResults.hidden = false;
+  });
+}
+
+// Hardcode to close the comparison results when "Close" is clicked.
+const modalCloseBtn = document.getElementById("modal-close");
+if (modalCloseBtn && comparisonResults) {
+  modalCloseBtn.addEventListener("click", () => {
+    comparisonResults.hidden = true;
+  });
+}
+
 // ---------- Init ----------
 renderTimeline();
 renderLLM();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -129,21 +129,104 @@
     </main>
   </div>
 
+
+  <!--Edit to hardcode the info into the compare feature. Hardcode articles into text inputs and hardcode the outputs-->
   <!-- COMPARE MODAL -->
   <div class="modal-overlay" id="compare-modal">
     <div class="modal">
       <button class="modal-close" id="modal-close">×</button>
       <h3>Select 2 articles or 2 dates to compare</h3>
-      <div class="compare-inputs">
+
+      <!--<div class="compare-inputs">
         <label>1. <input type="text" placeholder="Article or date" /></label>
         <label>2. <input type="text" placeholder="Article or date" /></label>
+      </div>-->
+
+      <div class="compare-inputs">
+        <label>1. 
+          <input type="text" value="There Is Much More to Pope vs. President Than Meets the Eye" />
+        </label>
+        <label>2. 
+          <input type="text" value="Trump, Pope Leo feud publicly. Here's who said what (and when)" />
+        </label>
       </div>
+      
+      <button class="run-compare-btn" id="run-compare-btn">
+        Compare Articles
+      </button>
+
+
+      <!--
       <div class="analysis-box">
         <div class="analysis-status">Generating Analysis...</div>
         <div class="analysis-placeholder"></div>
       </div>
+      -->
+
+      <!--<div class="analysis-box">-->
+      <div class="analysis-box" id="comparison-results" hidden>
+
+        <h4>Article Comparison</h4>
+      
+        <div class="compare-articles">
+          <div class="article-card">
+            <h5>Article 1 Perspective: Pope’s Moral Authority vs. Presidential Misconduct</h5>
+            <p><strong>Source:</strong> The New York Times (Opinion - 04/23/2026)</p>
+            <p><strong>Core Argument:</strong> Trump’s attacks on Pope Leo XIV reveal weak and erratic leadership, while elevating the Pope’s moral authority.</p>
+      
+            <p><strong>Key Points:</strong></p>
+            <ul>
+              <li>Questions morality of the U.S.-Iran war under Catholic "just war" doctrine.</li>
+              <li>Frames Trump’s insults as distraction from real ethical issues.</li>
+              <li>Argues misuse of religious imagery undermines political credibility.</li>
+            </ul>
+          </div>
+      
+          <div class="article-card">
+            <h5>Article 2 Perspective: A Necessary Challenge to Political Preaching</h5>
+            <p><strong>Source:</strong> USA Today (04/16/2026)</p>
+            <p><strong>Core Argument:</strong> Pope Leo XIV is acting like a politician and interfering in foreign policy.</p>
+      
+            <p><strong>Key Points:</strong></p>
+            <ul>
+              <li>Trump claims the Pope is "terrible for Foreign Policy".</li>
+              <li>Supporters argue the Pope misunderstands Iran.</li>
+              <li>Frames disagreement as justified pushback against overreach.</li>
+            </ul>
+          </div>
+        </div>
+      
+        <div class="differences">
+          <h4>Key Differences</h4>
+      
+          <p>
+            <strong>Moral Framing:</strong><br />
+            NYT → Ethical critique of war and leadership<br />
+            USA Today → Practical/political disagreement
+          </p>
+      
+          <p>
+            <strong>View of the Pope:</strong><br />
+            NYT → Moral authority<br />
+            USA Today → Political actor overstepping
+          </p>
+      
+          <p>
+            <strong>View of Trump:</strong><br />
+            NYT → Erratic and deflecting criticism<br />
+            USA Today → Justified in pushing back
+          </p>
+      
+          <p>
+            <strong>Overall Tone:</strong><br />
+            NYT → Critical, moral, analytical<br />
+            USA Today → Defensive, pragmatic, political
+          </p>
+        </div>
+      </div>
     </div>
   </div>
+   
 
   <!-- Hover tooltip -->
   <div id="tooltip" class="tooltip" hidden></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -583,8 +583,11 @@ body {
 
 .modal-overlay.open { display: flex; }
 
+/* Edit to fix sizing and allow comparison to fit on the pop up*/
 .modal {
-  width: min(520px, calc(100vw - 32px));
+  width: min(900px, calc(100vw - 32px));  /* wider */
+  max-height: 80vh;                      /* limit height */
+  overflow-y: auto;                      /* scroll instead of overflow */
   padding: 24px;
   position: relative;
   background: var(--white);
@@ -637,6 +640,18 @@ body {
   border-radius: 16px;
 }
 
+/* Edit to place article comparison side by side with proper spacing*/
+.compare-articles {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+  margin-bottom: 20px;
+}
+.compare-articles .article-card {
+  flex: 1;
+  margin-left: 0;  
+}
+
 .analysis-status {
   font-style: italic;
   color: var(--slate-500);
@@ -661,6 +676,7 @@ body {
   .app {
     flex-direction: column;
   }
+
 
   .menu {
     width: 100%;
@@ -687,4 +703,34 @@ body {
   .timeline-column::before {
     bottom: 6px;
   }
+}
+
+/*Edit to add a button within the compare pop up to run the comparison*/
+.run-compare-btn {
+  width: 100%;
+  margin: 10px 0 18px;
+  padding: 12px 18px;
+
+  border: none;
+  border-radius: 999px;
+
+  background: linear-gradient(135deg, var(--navy-950), var(--navy-800));
+  color: var(--white);
+
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+
+  cursor: pointer;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.18);
+
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.run-compare-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 26px rgba(15, 23, 42, 0.24);
+}
+.run-compare-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 14px rgba(15, 23, 42, 0.16);
 }


### PR DESCRIPTION
Adds a temporary hardcoded article comparison feature for demo purposes.
- Users click on the "compare" button to open modal and compare two articles.
- Article titles and comparison info are hardcoded.
- Comparisons appear after clicking "Compare Articles" button.
- Changes to the comparison layout for side by side comparison.

Will be replaced with LLM-based comparison later.