### PR TITLE
Add llm cards and fill with examples

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -366,8 +366,117 @@ document.getElementById("view-timeline").addEventListener("click", (e) => {
 // ---------- LLM view ----------
 
 const llmData = [
-  { name: "ChatGPT", summary: "", sources: "", leaning: "" },
-  { name: "Gemini",  summary: "", sources: "", leaning: "" },
+  {
+    name: "ChatGPT",
+    color: "#10a37f",
+    url: "https://chatgpt.com/s/t_69efdcf511d08191b5fa81803342b111",
+    summary: "A dramatized, narrative-heavy account that frames the feud as a major ideological clash between nationalism and global humanitarianism. It consistently favors Leo's position through asymmetric language and relies on a narrow set of center-left sources. The least factually precise of the three, with editorial bias baked into its structure and framing.",
+    biases: [
+      {
+        title: "Political / Framing Bias (Pro-Pope)",
+        body: `The response consistently frames Trump's positions with charged language (“hardline,” “personal attacks,” “unusually blunt”) while describing the pope's stances in neutral or positive terms (“moral restraint,” “peace,” “humanitarian focus”). This is asymmetric framing. Notably, the response omits that religion experts described the pope's words as “quite banal” and “the status quo of Catholic social teachings” — framing Leo as more of a reformer than he may actually be. It also omits Trump's specific, substantive criticisms (e.g., concerns about Iran's nuclear ambitions), which are present in the original source material.`,
+      },
+      {
+        title: "Source Bias",
+        body: "The response cites CBS News, Reuters, and Boston.com — all centrist-to-left-leaning outlets — with no counterbalancing sources from right-leaning media. This creates a one-sided evidentiary base. For example, polling data showing Trump's approval among Catholic voters actually rebounded during the feud is entirely absent, which would have complicated the narrative that Trump's attacks are broadly damaging.",
+      },
+      {
+        title: "False Equivalence / Asymmetry Bias",
+        body: `The response labels this a mutual “conflict” and “feud,” but one religion expert described it as a “one-way feud,” with Trump berating a critic. Calling it a two-sided clash inflates the pope's aggressiveness in the exchange.`,
+      },
+      {
+        title: "Omission Bias (Temporal)",
+        body: `The response presents the feud's origins somewhat loosely. The actual catalytic event was Operation Epic Fury, a joint U.S.-Israeli military operation beginning February 28, 2026 — a specific detail the chatbot omits, replacing it with vaguer language about a “2026 conflict involving Iran.” This obscures the timeline and reduces factual precision.`,
+      },
+      {
+        title: "Editorial / Structural Bias",
+        body: `The use of emoji headers (🔥⚔️🧠🌍🧩) and dramatic section labels like “What sparked the dispute” and “Main points of conflict” imposes a narrative arc that subtly dramatizes the story and primes the reader to see it as a significant moral clash rather than a political disagreement.`,
+      },
+    ],
+    sources: [
+      { label: "cbsnews.com — Trump-Pope Leo feud politics", url: "https://www.cbsnews.com/news/trump-pope-leo-feud-politics/" },
+      { label: "reuters.com — Pope Leo decries migrants", url: "https://www.reuters.com/world/pope-leo-decries-migrants-being-treated-worse-than-house-pets-2026-04-23/" },
+      { label: "boston.com — Trump lambasts Pope Leo XIV", url: "https://www.boston.com/news/politics/2026/04/12/trump-lambasts-pope-leo-xiv-extending-feud-over-iran-war-with-first-american-pontiff/" },
+      { label: "cbsnews.com — How dispute escalated", url: "https://www.cbsnews.com/news/how-dispute-trump-pope-leo-escalated/" },
+    ],
+  },
+  {
+    name: "Perplexity",
+    color: "#6e57e0",
+    url: "https://www.perplexity.ai/search/98d83dc7-a3f4-449f-a15b-e7a4b5acd894",
+    summary: "A clean, plain-prose account that presents both sides' positions without heavy editorializing or dramatic framing. Its weaknesses are mostly sins of omission — particularly missing polling data — and vague sourcing with no inline citations. Reads like a competent news brief but lacks the depth to fully contextualize the story.",
+    biases: [
+      {
+        title: "Framing Bias (Mild, Against Trump)",
+        body: `Trump “attacked” the pope, while Leo “took the stance” — subtly casting Trump as aggressor and Leo as principled respondent. Similarly, describing Leo as “defiant” carries a mildly heroic connotation that isn't balanced by an equivalently characterful word for Trump's persistence. The language is mostly even, but these small asymmetries add up.`,
+      },
+      {
+        title: "Omission Bias (Pope Leo's sharpening rhetoric)",
+        body: `The response describes Leo as speaking “from a moral and gospel-based perspective, not as a partisan politician” — but omits that the pope's own language sharpened over time, escalating from prayers for peace to calling the war “unjust” and labeling Trump's threat to destroy Iranian civilization “truly unacceptable.” Leaving this out makes Leo appear more passive and measured than the record shows.`,
+      },
+      {
+        title: "Source Bias (Implicit)",
+        body: `The response cites no sources at all, making it impossible to evaluate where the claims originate. The characterization that Leo has been “defiant and unwilling to back down” is attributed only vaguely to “reports” — a weak attribution that obscures potential editorial slant in the underlying sources.`,
+      },
+      {
+        title: "Omission Bias (Catholic polling data)",
+        body: `The “Why it matters” section says the feud has created “political fallout on the right,” implying Trump has been politically damaged. But polling data shows Trump's approval among Catholic voters actually rebounded in April despite the feud intensifying — a significant fact that contradicts the implied narrative of political cost.`,
+      },
+      {
+        title: "Temporal / Factual Vagueness",
+        body: "Like ChatGPT, this response never names the specific triggering event. Operation Epic Fury — the joint U.S.-Israeli military strike on Iran beginning February 28, 2026 — was the direct catalyst, and omitting it leaves the timeline fuzzy and harder to fact-check.",
+      },
+    ],
+    sources: [
+      { label: "youtube.com — PBS News Hour", url: "https://www.youtube.com/watch?v=Vt2l9sujNTk" },
+      { label: "nytimes.com — Republicans, Trump, Pope midterms", url: "https://www.nytimes.com/2026/04/17/us/politics/republicans-trump-pope-midterms.html" },
+      { label: "bbc.com — Trump-Pope Leo coverage", url: "https://www.bbc.com/news/articles/c070jxyjrmeo" },
+      { label: "pbs.org — Trump clashes with Pope Leo", url: "https://www.pbs.org/newshour/show/trump-clashes-with-pope-leo-who-vows-to-continue-speaking-out-against-war" },
+      { label: "npr.org — American Catholics in awkward spot", url: "https://www.npr.org/2026/04/18/nx-s1-5788718/tensions-between-president-trump-and-pope-leo-put-american-catholics-in-awkward-spot" },
+      { label: "cbsnews.com — Trump-Pope Leo feud politics", url: "https://www.cbsnews.com/news/trump-pope-leo-feud-politics/" },
+    ],
+  },
+  {
+    name: "Gemini",
+    color: "#4285f4",
+    url: "https://gemini.google.com/app/8adea3eab974b7d2",
+    summary: "A well-structured account that correctly names the triggering event and provides a useful comparison table of both positions. It contains one potentially hallucinated specific claim about an AI-generated image, and mildly favors Leo through subtle language choices. High-variance: well-organized and detailed but carries reliability risks from unverified specifics.",
+    biases: [
+      {
+        title: "Sensationalism / Hyperbole Bias",
+        body: `Calling this “one of the most high-profile diplomatic rifts in modern history” is unsupported editorializing. It overstates the significance of what religion experts have described as fairly routine papal behavior — “quite banal” and “the status quo of Catholic social teachings.”`,
+      },
+      {
+        title: "Fabrication Risk / Unverified Claim",
+        body: `The response mentions Trump sharing an AI-generated image depicting himself as Jesus-like, which “many Catholic leaders and the Vatican viewed as sacrilegious.” This specific claim does not appear in any of the verified sources reviewed. It may be accurate, but its inclusion without a citation in a context with other verifiable facts is a red flag for hallucination or embellishment.`,
+      },
+      {
+        title: "Framing Bias (Subtle, Pro-Leo)",
+        body: `The summary table is structurally fair, but the language choices favor Leo. His position on military action is described as “advocacy for non-violent resolution and 'just war' doctrine” — a sophisticated, theologically grounded framing — while Trump's is simply “necessary for global stability and ending nuclear threats,” which sounds blunter by comparison.`,
+      },
+      {
+        title: "Omission Bias (Catholic public opinion)",
+        body: "Like the previous two responses, this one omits polling showing Trump's approval among Catholic voters rebounded in April 2026 despite the feud intensifying — arguably the most important data point for understanding how the dispute has actually landed with the relevant public.",
+      },
+      {
+        title: "Quote Accuracy Issue",
+        body: `The response quotes Trump as saying to “stay in his lane” — but verified sources show Trump's actual language was to “get his act together as Pope, use Common Sense, stop catering to the Radical Left, and focus on being a Great Pope, not a Politician.” Paraphrasing quotes without flagging them as paraphrases misrepresents tone and substance.`,
+      },
+    ],
+    sources: [
+      { label: "whyy.org — Trump-Pope dispute, Catholics in Bucks County", url: "https://whyy.org/articles/trump-pope-dispute-catholics-bucks-county/" },
+      { label: "georgetown.edu — First American Pope", url: "https://www.georgetown.edu/news/what-it-means-for-the-first-american-to-be-chosen-as-pope/" },
+      { label: "war.gov — Operation Epic Fury", url: "https://www.war.gov/Spotlights/Operation-Epic-Fury/" },
+      { label: "americamagazine.org — Pope Leo on Iran war", url: "https://www.americamagazine.org/news/2026/04/10/pope-leo-war-iran-criticism/" },
+      { label: "usccb.org — Pope Leo calls for ceasefire", url: "https://www.usccb.org/news/2026/pope-leo-calls-ceasefire-middle-east-special-prayers-lebanon" },
+      { label: "livenowfox.com — Trump blasts Pope Leo XIV", url: "https://www.livenowfox.com/news/trump-blasts-pope-leo-xiv-truth-social-weak-crime-foreign-policy" },
+      { label: "cbsnews.com — How dispute escalated", url: "https://www.cbsnews.com/news/how-dispute-trump-pope-leo-escalated/" },
+      { label: "pbs.org — Trump says he doesn't owe Pope an apology", url: "https://www.pbs.org/newshour/politics/watch-trump-says-he-doesnt-owe-pope-leo-an-apology-after-attacking-him-for-comments-on-iran" },
+      { label: "wikipedia.org — 2026 US–Holy See rift", url: "https://en.wikipedia.org/wiki/2026_United_States%E2%80%93Holy_See_rift" },
+      { label: "ncregister.com — Trump-Pope Leo takeaways", url: "https://www.ncregister.com/commentaries/editorial-trump-pope-leo-takeaways" },
+      { label: "ncronline.org — Trump says he has right to disagree", url: "https://www.ncronline.org/news/trump-says-he-has-right-disagree-pope-leo-meeting-him-not-necessary" },
+    ],
+  },
 ];
 
 function renderLLM() {
@@ -375,14 +484,34 @@ function renderLLM() {
   wrap.innerHTML = "";
   llmData.forEach((m) => {
     const card = document.createElement("div");
-    card.className = "llm-card";
+    card.className = "llm-card collapsed";
+    card.style.borderTopColor = m.color;
+
+    const biasItems = m.biases.map((b, i) => `
+      <li class="llm-bias-item">
+        <span class="llm-bias-title">${i + 1}. ${b.title}</span>
+        <span class="llm-bias-body">${b.body}</span>
+      </li>
+    `).join("");
+
+    const sourceItems = m.sources.map((s) => `
+      <li><a href="${s.url}" target="_blank" rel="noopener">${s.label}</a></li>
+    `).join("");
+
     card.innerHTML = `
-      <h4>${m.name}</h4>
-      <div class="field"><strong>Summary:</strong> ${m.summary || "____"}</div>
-      <div class="field"><strong>Sources used:</strong> ${m.sources || "____"}</div>
-      <div class="field"><strong>Political leaning:</strong> ${m.leaning || "____"}</div>
-      <span class="chevron">⌄</span>
+      <div class="llm-card-header">
+        <a class="llm-name" href="${m.url}" target="_blank" rel="noopener">${m.name}</a>
+        <span class="chevron">›</span>
+      </div>
+      <p class="llm-summary">${m.summary}</p>
+      <div class="llm-card-detail">
+        <div class="llm-section-label">Bias Analysis</div>
+        <ol class="llm-bias-list">${biasItems}</ol>
+        <div class="llm-section-label">Sources</div>
+        <ul class="llm-sources-list">${sourceItems}</ul>
+      </div>
     `;
+
     card.querySelector(".chevron").addEventListener("click", () => {
       card.classList.toggle("collapsed");
       card.querySelector(".chevron").textContent = card.classList.contains("collapsed") ? "›" : "⌄";

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,7 +113,7 @@
 
       <!-- LLM VIEW -->
       <section id="view-llm" class="view">
-        <h2 class="sub-headline">Analysis on LLM's report on</h2>
+        <h2 class="sub-headline">Analysis on LLM's report on:</h2>
         <h3 class="story-headline">"Dispute Between Pope Leo &amp; Trump"</h3>
 
         <div class="llm-cards" id="llm-cards">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -575,47 +575,128 @@ body {
 }
 
 .llm-card {
-  position: relative;
-  padding: 18px 20px;
   background: rgba(255, 255, 255, 0.96);
   border: 1px solid rgba(203, 213, 225, 0.9);
+  border-top: 4px solid #94a3b8;
   border-radius: 20px;
   box-shadow: var(--shadow-card);
+  overflow: hidden;
 }
 
-.llm-card h4 {
-  margin: 0 0 12px;
-  font-size: 16px;
+.llm-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px 14px;
+}
+
+.llm-name {
+  font-size: 18px;
+  font-weight: 700;
   color: var(--navy-900);
+  text-decoration: none;
+  letter-spacing: -0.01em;
 }
 
-.llm-card .field {
-  padding: 8px 0;
-  font-size: 14px;
-  color: var(--slate-700);
-  border-bottom: 1px solid rgba(226, 232, 240, 0.95);
-}
-
-.llm-card .field:last-of-type {
-  border-bottom: none;
-}
-
-.llm-card .field strong {
-  margin-right: 6px;
-  color: var(--navy-900);
+.llm-name:hover {
+  text-decoration: underline;
+  color: var(--navy-800);
 }
 
 .llm-card .chevron {
-  position: absolute;
-  right: 18px;
-  bottom: 14px;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 22px;
   color: var(--slate-500);
   user-select: none;
+  line-height: 1;
 }
 
-.llm-card.collapsed .field:not(:first-child) { display: none; }
+.llm-summary {
+  margin: 0;
+  padding: 14px 22px 18px;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--slate-700);
+  background: var(--slate-100);
+  border-top: 1px solid rgba(203, 213, 225, 0.7);
+  border-bottom: 1px solid rgba(203, 213, 225, 0.7);
+}
+
+.llm-card-detail {
+  padding: 20px 22px 22px;
+}
+
+.llm-card.collapsed .llm-card-detail {
+  display: none;
+}
+
+.llm-section-label {
+  margin: 24px 0 10px;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--navy-800);
+}
+
+.llm-section-label:first-child {
+  margin-top: 0;
+}
+
+.llm-bias-list {
+  margin: 0 0 4px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.llm-bias-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.85);
+}
+
+.llm-bias-item:last-child {
+  border-bottom: none;
+}
+
+.llm-bias-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--navy-900);
+}
+
+.llm-bias-body {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--slate-700);
+}
+
+.llm-sources-list {
+  margin: 0;
+  padding: 0 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.llm-sources-list li {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.llm-sources-list a {
+  color: var(--navy-800);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.llm-sources-list a:hover {
+  text-decoration: underline;
+}
 
 /* MODAL */
 .modal-overlay {


### PR DESCRIPTION
Update LLM view to show example cards:
- Add three LLM cards, ChatGPT, Perplexity, Gemini
- Each card has summary of response, chat-link, 5 bias topics, and sources
- Card is collapsed by default showing only summary