### PR TITLE
Update compare article feature workflow to support article selection

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -45,6 +45,8 @@ function sourceColor(src) {
 // Global state — populated after fetch
 let timelineData = [];
 let channelData  = {};
+let selectedCompareTitles = [];
+let selectedCompareArticles = [];
 
 // ---------- Data loading ----------
 
@@ -274,6 +276,7 @@ function makeArticleCard(a) {
   card.addEventListener("mousemove", (e) => showTooltip(e, a.summary));
   card.addEventListener("mouseleave", hideTooltip);
   card.querySelector(".src").addEventListener("click", (e) => {
+    if (document.body.classList.contains("compare-mode")) return;
     e.stopPropagation();
     if (selectedTimelineSource === a.src) {
       clearTimelineSourceSelection();
@@ -284,8 +287,57 @@ function makeArticleCard(a) {
     setTimelineSourceSelection(a.src);
   });
   card.addEventListener("click", () => {
+    if (document.body.classList.contains("compare-mode")) {
+      const title = a.title;
+  
+      if (selectedCompareTitles.includes(title)) {
+
+        // REMOVE TITLE
+        selectedCompareTitles = selectedCompareTitles.filter(t => t !== title);
+      
+        // REMOVE ARTICLE OBJECT
+        selectedCompareArticles =
+          selectedCompareArticles.filter(article => article.title !== title);
+      
+        card.style.border = "";
+        card.style.backgroundColor = "";
+      
+      } else {
+      
+        if (selectedCompareTitles.length >= 2) {
+          alert("You can only select 2 articles.");
+          return;
+        }
+      
+        // ADD TITLE
+        selectedCompareTitles.push(title);
+      
+        // ADD FULL ARTICLE OBJECT
+        selectedCompareArticles.push(a);
+      
+        card.style.border = "4px solid #2563eb";
+        card.style.backgroundColor = "rgba(37, 99, 235, 0.12)";
+      }
+  
+      // BUTTON TEXT LOGIC
+      if (selectedCompareTitles.length === 0) {
+        runCompareBtn.textContent = "Select 2 articles";
+      }
+  
+      if (selectedCompareTitles.length === 1) {
+        runCompareBtn.textContent = "Select 1 more article";
+      }
+  
+      if (selectedCompareTitles.length >= 2) {
+        runCompareBtn.textContent = "Compare Selected Articles";
+      }
+  
+      return;
+    }
+  
     if (a.url) window.open(a.url, "_blank");
   });
+  
   return card;
 }
 
@@ -325,10 +377,33 @@ function hideTooltip() { tooltipEl.hidden = true; }
 // ---------- Compare modal ----------
 
 const modal = document.getElementById("compare-modal");
-document.getElementById("compare-btn").addEventListener("click", () => modal.classList.add("open"));
-document.getElementById("modal-close").addEventListener("click", () => modal.classList.remove("open"));
-modal.addEventListener("click", (e) => { if (e.target === modal) modal.classList.remove("open"); });
 
+function resetArticleComparison() {
+  selectedCompareTitles = [];
+  selectedCompareArticles = [];
+
+  document.getElementById("selected-article-links").innerHTML = "";
+
+  document.querySelectorAll(".article-card").forEach(card => {
+    card.style.border = "";
+    card.style.backgroundColor = "";
+  });
+
+  runCompareBtn.textContent = "Article Comparison";
+  document.body.classList.remove("compare-mode");
+}
+
+document.getElementById("modal-close").addEventListener("click", () => {
+  modal.classList.remove("open");
+  resetArticleComparison();
+});
+
+modal.addEventListener("click", (e) => {
+  if (e.target === modal) {
+    modal.classList.remove("open");
+    resetArticleComparison();
+  }
+});
 // ---------- Channels view ----------
 
 function showChannelsGrid() {
@@ -556,12 +631,42 @@ function renderLLM() {
   });
 }
 
-// Hardcode to show comparison results when "Run Comparison" is clicked, since we don't have real LLM outputs in this prototype.
-const runCompareBtn = document.getElementById("run-compare-btn");
+// Show comparison results after selecting articles
+const runCompareBtn = document.getElementById("compare-btn");
 const comparisonResults = document.getElementById("comparison-results");
+
 if (runCompareBtn && comparisonResults) {
   runCompareBtn.addEventListener("click", () => {
+    console.log("compare button clicked");
+    console.log("selected count:", selectedCompareTitles.length);
+
+    if (!document.body.classList.contains("compare-mode")) {
+      document.body.classList.add("compare-mode");
+      selectedCompareTitles = [];
+      runCompareBtn.textContent = "Select 2 articles";
+      return;
+    }
+
+    if (selectedCompareTitles.length < 2) {
+      alert("Select 2 articles to compare.");
+      return;
+    }
+    const selectedLinksEl = document.getElementById("selected-article-links");
+
+    selectedLinksEl.innerHTML = selectedCompareArticles
+      .map((article, index) => `
+        <div style="margin-bottom: 10px;">
+          <strong>Article ${index + 1}:</strong>
+          <strong>${article.title}</strong>
+          <a href="${article.url}" target="_blank">[Link]</a>
+        </div>
+      `)
+      .join("");
+  
+    modal.classList.add("open");
     comparisonResults.hidden = false;
+
+
   });
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,7 +92,7 @@
             <div class="timeline-columns" id="timeline-columns">
               <!-- Columns injected by JS -->
             </div>
-            <button class="compare-btn" id="compare-btn">COMPARE</button>
+            <button class="compare-btn" id="compare-btn">Article Comparison</button>
           </div>
         </div>
       </section>
@@ -132,18 +132,12 @@
   <div class="modal-overlay" id="compare-modal">
     <div class="modal">
       <button class="modal-close" id="modal-close">×</button>
-      <h3>Select 2 articles or 2 dates to compare</h3>
+      <h3>Selected Articles</h3>
 
-      <div class="compare-inputs">
-        <label>1.
-          <input type="text" value="There Is Much More to Pope vs. President Than Meets the Eye" />
-        </label>
-        <label>2.
-          <input type="text" value="Trump, Pope Leo feud publicly. Here's who said what (and when)" />
-        </label>
+      <div id="selected-article-links" class="selected-article-links">
+        <a href="#" target="_blank">Article 1 title</a>
+        <a href="#" target="_blank">Article 2 title</a>
       </div>
-
-      <button class="run-compare-btn" id="run-compare-btn">Compare Articles</button>
 
       <div class="analysis-box" id="comparison-results" hidden>
         <h4>Article Comparison</h4>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -911,3 +911,20 @@ body {
   .filters.open { width: 100%; min-width: 0; }
   .timeline-column { width: 200px; min-width: 200px; }
 }
+
+
+
+
+
+
+
+.compare-mode .article-card {
+  cursor: pointer;
+}
+
+.selected-compare {
+  border: 4px solid #2563eb !important;
+  background-color: rgba(37, 99, 235, 0.2) !important;
+  transform: scale(1.02);
+  box-shadow: 0 0 12px rgba(37, 99, 235, 0.5);
+}


### PR DESCRIPTION
Updated the article comparison workflow to support direct article selection from the timeline UI instead of manual title input.

Changes:
- Users can now select up to 2 articles directly from the timeline
- Added dynamic compare button states: "Article Comparison", "Select 2 articles", "Select 1 more article", "Compare Selected Articles"
- Added visual highlighting for selected article cards
- Updated compare modal to display selected article titles with clickable links
- Removed manual search bar/article input in the modal
- Added article reset behavior when exiting comparison mode or closing modal
Improved overall compare flow UX to better match timeline interaction behavior
