### PR TITLE
fixing some issues + user bias feature 

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,9 +1,6 @@
 name: Refresh Articles
 
 on:
-  schedule:
-    - cron: "0 16 * * *"
-
   workflow_dispatch:
     inputs:
       query:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1142,7 +1142,7 @@ async function renderAccountView() {
     if (lean && leanCounts[lean] !== undefined) leanCounts[lean]++;
   }
   const totalLean = leanCounts.Left + leanCounts.Center + leanCounts.Right;
-  const dominantLean = totalLean > 0
+  const dominantLean = totalLean >= 3
     ? Object.entries(leanCounts).sort((a, b) => b[1] - a[1])[0][0] : null;
   const blindSpotLean = dominantLean === "Left" ? "Right" : dominantLean === "Right" ? "Left" : null;
 
@@ -1174,10 +1174,10 @@ async function renderAccountView() {
         <div class="profile-block">
           <div class="profile-block-label">Your Blind Spot</div>
           ${!currentQuery ? `<div class="bookmarks-empty" style="padding:16px 0">Search for a topic first to see your blind spot.</div>`
-          : totalLean === 0 ? `<div class="bookmarks-empty" style="padding:16px 0">Click some articles on "${currentQuery}" to see which side you're reading.</div>`
+          : totalLean < 3 ? `<div class="bookmarks-empty" style="padding:16px 0">Read at least 3 articles on "${currentQuery}" to see your blind spot (${totalLean}/3 so far).</div>`
           : !blindSpotLean ? `<div class="bookmarks-empty" style="padding:16px 0">Your reading on this topic looks balanced.</div>`
           : `
-            <div class="blindspot-desc">On <strong>"${currentQuery}"</strong> you've mostly read <strong>${dominantLean}-leaning</strong> sources. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
+            <div class="blindspot-desc">Based on ${totalLean} articles you've read on <strong>"${currentQuery}"</strong>, you lean <strong>${dominantLean}</strong>. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
             ${blindSpotArticles.length ? `
               <div class="blindspot-list">
                 ${blindSpotArticles.map(a => `

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1104,28 +1104,52 @@ async function renderAccountView() {
   ]);
 
   // --- Reading profile ---
-  const viewedUrls = new Set((history || []).map(h => h.article_url));
-  const leanCounts = { Left: 0, Center: 0, Right: 0 };
+  // Build source-level lean from biasMap (normalized source names as fallback)
+  const srcLeanTally = {};
+  for (const b of Object.values(biasMap)) {
+    if (!b.source || !b.bias_label) continue;
+    const s = cleanSourceName(b.source);
+    if (!srcLeanTally[s]) srcLeanTally[s] = { Left: 0, Center: 0, Right: 0 };
+    if (srcLeanTally[s][b.bias_label] !== undefined) srcLeanTally[s][b.bias_label]++;
+  }
+  const srcLeanMap = {};
+  for (const [s, counts] of Object.entries(srcLeanTally)) {
+    srcLeanMap[s] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0];
+  }
+
+  function articleLean(url, src) {
+    return biasMap[url]?.bias_label || srcLeanMap[src] || null;
+  }
+
+  // Top sources: all-time history
   const sourceCounts = {};
   for (const h of (history || [])) {
     const src = h.article_src || "Unknown";
     sourceCounts[src] = (sourceCounts[src] || 0) + 1;
-    const bias = biasMap[h.article_url];
-    if (bias?.bias_label && leanCounts[bias.bias_label] !== undefined) leanCounts[bias.bias_label]++;
   }
   const topSources = Object.entries(sourceCounts).sort((a, b) => b[1] - a[1]).slice(0, 3);
   const maxCount = topSources[0]?.[1] || 1;
+
+  // Blind spot: per-topic (only views matching current search articles)
+  const allCurrentArticles = Object.entries(channelData).flatMap(([src, arts]) => arts.map(a => ({ ...a, src })));
+  const currentArticleUrls = new Set(allCurrentArticles.map(a => a.url));
+  const viewedUrls = new Set((history || []).map(h => h.article_url));
+  const topicViews = (history || []).filter(h => currentArticleUrls.has(h.article_url));
+
+  const leanCounts = { Left: 0, Center: 0, Right: 0 };
+  for (const h of topicViews) {
+    const lean = articleLean(h.article_url, h.article_src);
+    if (lean && leanCounts[lean] !== undefined) leanCounts[lean]++;
+  }
   const totalLean = leanCounts.Left + leanCounts.Center + leanCounts.Right;
   const dominantLean = totalLean > 0
     ? Object.entries(leanCounts).sort((a, b) => b[1] - a[1])[0][0] : null;
   const blindSpotLean = dominantLean === "Left" ? "Right" : dominantLean === "Right" ? "Left" : null;
 
-  const allCurrentArticles = Object.entries(channelData).flatMap(([src, arts]) => arts.map(a => ({ ...a, src })));
   const blindSpotArticles = [];
   if (blindSpotLean) {
     for (const a of allCurrentArticles) {
-      const bias = biasMap[a.url];
-      if (bias?.bias_label === blindSpotLean && !viewedUrls.has(a.url)) {
+      if (articleLean(a.url, a.src) === blindSpotLean && !viewedUrls.has(a.url)) {
         blindSpotArticles.push(a);
         if (blindSpotArticles.length >= 2) break;
       }
@@ -1147,19 +1171,23 @@ async function renderAccountView() {
               <span class="source-bar-count">${count}</span>
             </div>`).join("")}
         </div>
-        ${blindSpotLean ? `
         <div class="profile-block">
           <div class="profile-block-label">Your Blind Spot</div>
-          <div class="blindspot-desc">You mostly read <strong>${dominantLean}-leaning</strong> sources. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
-          ${blindSpotArticles.length ? `
-            <div class="blindspot-list">
-              ${blindSpotArticles.map(a => `
-                <a href="${a.url}" target="_blank" rel="noopener" class="blindspot-article">
-                  <span class="blindspot-src"><span class="dot" style="background:${sourceColor(a.src)}"></span>${a.src}</span>
-                  <span class="blindspot-title">${a.title}</span>
-                </a>`).join("")}
-            </div>` : `<div class="bookmarks-empty" style="padding:16px 0">Search for articles to see suggestions here.</div>`}
-        </div>` : ""}
+          ${!currentQuery ? `<div class="bookmarks-empty" style="padding:16px 0">Search for a topic first to see your blind spot.</div>`
+          : totalLean === 0 ? `<div class="bookmarks-empty" style="padding:16px 0">Click some articles on "${currentQuery}" to see which side you're reading.</div>`
+          : !blindSpotLean ? `<div class="bookmarks-empty" style="padding:16px 0">Your reading on this topic looks balanced.</div>`
+          : `
+            <div class="blindspot-desc">On <strong>"${currentQuery}"</strong> you've mostly read <strong>${dominantLean}-leaning</strong> sources. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
+            ${blindSpotArticles.length ? `
+              <div class="blindspot-list">
+                ${blindSpotArticles.map(a => `
+                  <a href="${a.url}" target="_blank" rel="noopener" class="blindspot-article">
+                    <span class="blindspot-src"><span class="dot" style="background:${sourceColor(a.src)}"></span>${a.src}</span>
+                    <span class="blindspot-title">${a.title}</span>
+                  </a>`).join("")}
+              </div>` : `<div class="bookmarks-empty" style="padding:16px 0">No unread ${blindSpotLean}-leaning articles found for this topic.</div>`}
+          `}
+        </div>
       </div>
     </div>` : "";
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1226,7 +1226,7 @@ async function renderAccountView() {
           : topicViews.length < 3 ? `<div class="bookmarks-empty" style="padding:16px 0">Read at least 3 articles on "${currentQuery}" to see your blind spot (${topicViews.length}/3 so far).</div>`
           : !blindSpotLean ? `<div class="bookmarks-empty" style="padding:16px 0">Your reading on this topic looks balanced.</div>`
           : `
-            <div class="blindspot-desc">Based on ${totalLean} articles you've read on <strong>"${currentQuery}"</strong>, you lean <strong>${dominantLean}</strong>. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
+            <div class="blindspot-desc">Based on ${totalLean} articles you've clicked on <strong>"${currentQuery}"</strong>, you've read more <strong>${dominantLean}-leaning</strong> sources. These <strong>${blindSpotLean}-leaning</strong> articles haven't been on your radar:</div>
             ${blindSpotArticles.length ? `
               <div class="blindspot-list">
                 ${blindSpotArticles.map(a => `

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -46,6 +46,68 @@ async function loadUserBookmarks() {
 const TOP_N_PER_DATE = 5;
 
 // Higher number = more credible. Sources not listed default to tier 1.
+// Source lean ratings based on AllSides / Ad Fontes Media.
+// Keys cover both cleaned domain names (after cleanSourceName) and formatted API names.
+const SOURCE_LEAN = {
+  // Left
+  "cnn": "Left", "CNN": "Left",
+  "msnbc": "Left", "MSNBC": "Left",
+  "huffpost": "Left", "HuffPost": "Left", "huffingtonpost": "Left",
+  "motherjones": "Left", "Mother Jones": "Left",
+  "vox": "Left", "Vox": "Left",
+  "slate": "Left", "Slate": "Left",
+  "thenation": "Left", "The Nation": "Left",
+  "rawstory": "Left", "Raw Story": "Left",
+  "crooksandliars": "Left", "Crooksandliars": "Left",
+  "truthout": "Left", "Truthout": "Left",
+  "juancole": "Left", "Juancole": "Left",
+  "aljazeera": "Left", "Al Jazeera": "Left",
+  "nytimes": "Left", "New York Times": "Left",
+  "washingtonpost": "Left", "Washington Post": "Left",
+  "theguardian": "Left", "Guardian": "Left",
+  "nbcnews": "Left", "NBC News": "Left",
+  "cbsnews": "Left", "CBS News": "Left",
+  "abcnews": "Left", "ABC News": "Left", "abc": "Left",
+  "npr": "Left", "NPR": "Left",
+  "pbs": "Left", "PBS": "Left",
+  "theatlantic": "Left", "The Atlantic": "Left", "atlantic": "Left",
+  "politico": "Left", "Politico": "Left",
+  "time": "Left", "Time": "Left",
+  "thedailybeast": "Left", "Daily Beast": "Left",
+  "salon": "Left", "Salon": "Left",
+  "msn": "Left", "MSN": "Left",
+  "consequence": "Left", "Consequence": "Left",
+  "globalresearch": "Left", "Globalresearch": "Left",
+  // Center
+  "apnews": "Center", "AP News": "Center", "Associated Press": "Center",
+  "reuters": "Center", "Reuters": "Center",
+  "bbc": "Center", "BBC": "Center", "BBC News": "Center",
+  "usatoday": "Center", "USA Today": "Center",
+  "thehill": "Center", "The Hill": "Center",
+  "bloomberg": "Center", "Bloomberg": "Center",
+  "axios": "Center", "Axios": "Center",
+  "theconversation": "Center", "The Conversation": "Center",
+  "mediaite": "Center", "Mediaite": "Center",
+  "perthnow": "Center",
+  "independent": "Center", "Independent": "Center",
+  "standard": "Center",
+  // Right
+  "foxnews": "Right", "Fox News": "Right",
+  "nypost": "Right", "New York Post": "Right",
+  "wsj": "Right", "Wall Street Journal": "Right",
+  "breitbart": "Right", "Breitbart": "Right",
+  "dailywire": "Right", "Daily Wire": "Right",
+  "newsmax": "Right", "Newsmax": "Right",
+  "washingtonexaminer": "Right", "Washington Examiner": "Right",
+  "washingtontimes": "Right", "Washington Times": "Right",
+  "epochtimes": "Right", "Epoch Times": "Right",
+  "thefederalist": "Right", "The Federalist": "Right",
+  "dailymail": "Right", "Daily Mail": "Right",
+  "dailycaller": "Right", "Daily Caller": "Right",
+  "oann": "Right", "OAN": "Right",
+  "nypost": "Right", "New York Post": "Right",
+};
+
 const SOURCE_CREDIBILITY = {
   "New York Times": 3,
   "theguardian":    3,
@@ -211,7 +273,7 @@ async function runSearchQuery(query) {
   const { results } = await res.json();
   currentQuery = query;
   try { sessionStorage.setItem("lastSearch", JSON.stringify({ query, results })); } catch (_) {}
-  await loadAndRender(query, results);
+  await Promise.all([loadAndRender(query, results), loadBias()]);
   setStoryHeadline(query);
 }
 
@@ -1104,21 +1166,8 @@ async function renderAccountView() {
   ]);
 
   // --- Reading profile ---
-  // Build source-level lean from biasMap (normalized source names as fallback)
-  const srcLeanTally = {};
-  for (const b of Object.values(biasMap)) {
-    if (!b.source || !b.bias_label) continue;
-    const s = cleanSourceName(b.source);
-    if (!srcLeanTally[s]) srcLeanTally[s] = { Left: 0, Center: 0, Right: 0 };
-    if (srcLeanTally[s][b.bias_label] !== undefined) srcLeanTally[s][b.bias_label]++;
-  }
-  const srcLeanMap = {};
-  for (const [s, counts] of Object.entries(srcLeanTally)) {
-    srcLeanMap[s] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0];
-  }
-
   function articleLean(url, src) {
-    return biasMap[url]?.bias_label || srcLeanMap[src] || null;
+    return biasMap[url]?.bias_label || SOURCE_LEAN[src] || SOURCE_LEAN[cleanSourceName(src)] || null;
   }
 
   // Top sources: all-time history
@@ -1142,7 +1191,7 @@ async function renderAccountView() {
     if (lean && leanCounts[lean] !== undefined) leanCounts[lean]++;
   }
   const totalLean = leanCounts.Left + leanCounts.Center + leanCounts.Right;
-  const dominantLean = totalLean >= 3
+  const dominantLean = topicViews.length >= 3
     ? Object.entries(leanCounts).sort((a, b) => b[1] - a[1])[0][0] : null;
   const blindSpotLean = dominantLean === "Left" ? "Right" : dominantLean === "Right" ? "Left" : null;
 
@@ -1174,7 +1223,7 @@ async function renderAccountView() {
         <div class="profile-block">
           <div class="profile-block-label">Your Blind Spot</div>
           ${!currentQuery ? `<div class="bookmarks-empty" style="padding:16px 0">Search for a topic first to see your blind spot.</div>`
-          : totalLean < 3 ? `<div class="bookmarks-empty" style="padding:16px 0">Read at least 3 articles on "${currentQuery}" to see your blind spot (${totalLean}/3 so far).</div>`
+          : topicViews.length < 3 ? `<div class="bookmarks-empty" style="padding:16px 0">Read at least 3 articles on "${currentQuery}" to see your blind spot (${topicViews.length}/3 so far).</div>`
           : !blindSpotLean ? `<div class="bookmarks-empty" style="padding:16px 0">Your reading on this topic looks balanced.</div>`
           : `
             <div class="blindspot-desc">Based on ${totalLean} articles you've read on <strong>"${currentQuery}"</strong>, you lean <strong>${dominantLean}</strong>. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -192,6 +192,7 @@ landingBtn.addEventListener("click", triggerSearch);
 landingInput.addEventListener("keydown", (e) => { if (e.key === "Enter") triggerSearch(); });
 
 document.getElementById("new-search-btn").addEventListener("click", () => {
+  sessionStorage.removeItem("lastSearch");
   landingEl.classList.remove("hidden");
   landingStatus.hidden = true;
   landingBtn.disabled = false;
@@ -209,6 +210,7 @@ async function runSearchQuery(query) {
   if (!res.ok) throw new Error((await res.json()).error || "Search failed");
   const { results } = await res.json();
   currentQuery = query;
+  try { sessionStorage.setItem("lastSearch", JSON.stringify({ query, results })); } catch (_) {}
   await loadAndRender(query, results);
   setStoryHeadline(query);
 }
@@ -1098,8 +1100,68 @@ async function renderAccountView() {
 
   const [{ data: bookmarks }, { data: history }] = await Promise.all([
     sb.from("bookmarks").select("*").order("bookmarked_at", { ascending: false }),
-    sb.from("article_views").select("*").order("viewed_at", { ascending: false }).limit(5),
+    sb.from("article_views").select("*").order("viewed_at", { ascending: false }).limit(50),
   ]);
+
+  // --- Reading profile ---
+  const viewedUrls = new Set((history || []).map(h => h.article_url));
+  const leanCounts = { Left: 0, Center: 0, Right: 0 };
+  const sourceCounts = {};
+  for (const h of (history || [])) {
+    const src = h.article_src || "Unknown";
+    sourceCounts[src] = (sourceCounts[src] || 0) + 1;
+    const bias = biasMap[h.article_url];
+    if (bias?.bias_label && leanCounts[bias.bias_label] !== undefined) leanCounts[bias.bias_label]++;
+  }
+  const topSources = Object.entries(sourceCounts).sort((a, b) => b[1] - a[1]).slice(0, 3);
+  const maxCount = topSources[0]?.[1] || 1;
+  const totalLean = leanCounts.Left + leanCounts.Center + leanCounts.Right;
+  const dominantLean = totalLean > 0
+    ? Object.entries(leanCounts).sort((a, b) => b[1] - a[1])[0][0] : null;
+  const blindSpotLean = dominantLean === "Left" ? "Right" : dominantLean === "Right" ? "Left" : null;
+
+  const allCurrentArticles = Object.entries(channelData).flatMap(([src, arts]) => arts.map(a => ({ ...a, src })));
+  const blindSpotArticles = [];
+  if (blindSpotLean) {
+    for (const a of allCurrentArticles) {
+      const bias = biasMap[a.url];
+      if (bias?.bias_label === blindSpotLean && !viewedUrls.has(a.url)) {
+        blindSpotArticles.push(a);
+        if (blindSpotArticles.length >= 2) break;
+      }
+    }
+  }
+
+  const profileHTML = topSources.length > 0 ? `
+    <div class="reading-profile-card">
+      <h3 class="bookmarks-heading">Your Reading Profile</h3>
+      <div class="profile-grid">
+        <div class="profile-block">
+          <div class="profile-block-label">Top Sources</div>
+          ${topSources.map(([src, count]) => `
+            <div class="source-bar-row">
+              <span class="source-bar-name"><span class="dot" style="background:${sourceColor(src)}"></span>${src}</span>
+              <div class="source-bar-track">
+                <div class="source-bar-fill" style="width:${(count / maxCount * 100).toFixed(0)}%;background:${sourceColor(src)}"></div>
+              </div>
+              <span class="source-bar-count">${count}</span>
+            </div>`).join("")}
+        </div>
+        ${blindSpotLean ? `
+        <div class="profile-block">
+          <div class="profile-block-label">Your Blind Spot</div>
+          <div class="blindspot-desc">You mostly read <strong>${dominantLean}-leaning</strong> sources. These ${blindSpotLean}-leaning articles haven't been on your radar:</div>
+          ${blindSpotArticles.length ? `
+            <div class="blindspot-list">
+              ${blindSpotArticles.map(a => `
+                <a href="${a.url}" target="_blank" rel="noopener" class="blindspot-article">
+                  <span class="blindspot-src"><span class="dot" style="background:${sourceColor(a.src)}"></span>${a.src}</span>
+                  <span class="blindspot-title">${a.title}</span>
+                </a>`).join("")}
+            </div>` : `<div class="bookmarks-empty" style="padding:16px 0">Search for articles to see suggestions here.</div>`}
+        </div>` : ""}
+      </div>
+    </div>` : "";
 
   const cards = (bookmarks || []).map(b => `
     <div class="bookmark-card">
@@ -1115,7 +1177,7 @@ async function renderAccountView() {
       <button class="bookmark-remove" data-id="${b.id}">Remove</button>
     </div>`).join("");
 
-  const historyCards = (history || []).map(h => `
+  const historyCards = (history || []).slice(0, 5).map(h => `
     <div class="bookmark-card">
       <div class="bookmark-meta">
         <span class="dot" style="background:${sourceColor(h.article_src)}"></span>
@@ -1135,7 +1197,8 @@ async function renderAccountView() {
       </div>
       <button class="signout-btn" id="signout-btn">Sign Out</button>
     </div>
-    <h3 class="bookmarks-heading">Recently Viewed</h3>
+    ${profileHTML}
+    <h3 class="bookmarks-heading" style="margin-top:28px">Recently Viewed</h3>
     ${history?.length
       ? `<div class="bookmarks-list">${historyCards}</div>`
       : `<div class="bookmarks-empty">No history yet — click any article to open it.</div>`}
@@ -1280,6 +1343,19 @@ async function init() {
   document.getElementById("gate-signup-btn").addEventListener("click", () => handleGateAuth("signup"));
 
   renderLLM();
+
+  const savedSearch = sessionStorage.getItem("lastSearch");
+  if (savedSearch) {
+    try {
+      const { query, results } = JSON.parse(savedSearch);
+      currentQuery = query;
+      landingEl.classList.add("hidden");
+      await loadAndRender(query, results);
+      setStoryHeadline(query);
+    } catch (_) {
+      sessionStorage.removeItem("lastSearch");
+    }
+  }
 }
 
 init();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1515,3 +1515,107 @@ body {
   cursor: pointer;
 }
 .bookmark-remove:hover { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+
+/* ── READING PROFILE ───────────────────────────────────── */
+.reading-profile-card {
+  margin-bottom: 28px;
+}
+.profile-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 600px) {
+  .profile-grid { grid-template-columns: 1fr; }
+}
+.profile-block {
+  padding: 18px 20px;
+  background: var(--white);
+  border: 1px solid var(--slate-200);
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+}
+.profile-block-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--slate-400);
+  margin-bottom: 14px;
+}
+.source-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.source-bar-name {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--navy-800);
+  min-width: 0;
+  flex: 0 0 auto;
+  max-width: 110px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.source-bar-track {
+  flex: 1;
+  height: 6px;
+  background: var(--slate-100);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.source-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  opacity: 0.7;
+  transition: width 0.4s ease;
+}
+.source-bar-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--slate-400);
+  flex: 0 0 auto;
+}
+.blindspot-desc {
+  font-size: 13px;
+  color: var(--slate-600);
+  line-height: 1.5;
+  margin-bottom: 14px;
+}
+.blindspot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.blindspot-article {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  background: var(--slate-50);
+  border: 1px solid var(--slate-200);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.blindspot-article:hover { background: var(--accent-light); border-color: var(--accent-mid); }
+.blindspot-src {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--slate-400);
+}
+.blindspot-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--navy-950);
+  line-height: 1.4;
+}


### PR DESCRIPTION
- Remove 8am cron from refresh workflow (keep manual refresh button)
- Persist last search in sessionStorage so browser refresh restores timeline
- Add "Your Reading Profile" section to Account tab:
  - Top 3 sources bar chart (all-time history)
  - Blind spot panel: detects per-topic lean from clicked articles,
    surfaces unread articles from the opposite side
- Replace broken ML bias labels with AllSides-based SOURCE_LEAN map;
  Julien's biasMap still takes priority, SOURCE_LEAN is fallback
- Reload bias data after each search to pick up fresh pipeline output
- Require 3 topic clicks before showing blind spot; counter shows progress
- Soften blind spot copy: "clicked more X-leaning" vs "you lean X"