### PR TITLE
Add AI-generated channel summaries

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -108,6 +108,23 @@ Record a user action. Fire-and-forget — the frontend does not need to await or
 `search` payload: `{ "query": "..." }`.  
 Returns `204 No Content`.
 
+### `POST /api/channel-summary`
+
+Generate a short AI overview of one source's loaded articles. Requires `OPENAI_API_KEY`.
+
+```json
+{
+  "source": "New York Times",
+  "articles": [
+    {
+      "title": "...",
+      "summary": "...",
+      "date": "2026-05-30"
+    }
+  ]
+}
+```
+
 ---
 
 ## Environment variables
@@ -117,6 +134,7 @@ Returns `204 No Content`.
 | ----------- | ------------------------ | ------------------------- |
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection string   |
 | `DATA_PATH` | `data/articles.json`     | Path to article JSON file |
+| `OPENAI_API_KEY` | — | OpenAI API key used for article comparisons and channel summaries |
 
 
 Add both to `.env` (see `.env.example`). For Vercel, provision Upstash Redis from the Marketplace and set `REDIS_URL` in project settings.

--- a/backend/channel_summary.py
+++ b/backend/channel_summary.py
@@ -1,0 +1,66 @@
+import os
+
+from fastapi import APIRouter, HTTPException
+from openai import OpenAI
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class ChannelArticle(BaseModel):
+    title: str
+    summary: str | None = ""
+    date: str | None = ""
+
+
+class ChannelSummaryRequest(BaseModel):
+    source: str
+    articles: list[ChannelArticle]
+
+
+@router.post("/api/channel-summary")
+async def summarize_channel(req: ChannelSummaryRequest):
+    if not req.articles:
+        raise HTTPException(status_code=400, detail="At least one article is required.")
+
+    article_blocks = "\n\n".join(
+        f"""Article {index}:
+Date: {article.date}
+Title: {article.title}
+Summary: {article.summary}"""
+        for index, article in enumerate(req.articles[:20], start=1)
+    )
+
+    prompt = f"""
+Write a concise overview of {req.source}'s coverage using only the supplied articles.
+
+{article_blocks}
+
+Summarize the main angle, recurring themes, and any meaningful development over time.
+If only one article is supplied, describe that article's focus without claiming a recurring pattern.
+Do not infer political bias, editorial intent, or facts that are not supported by the supplied text.
+Write two short paragraphs in plain text. Do not use headings, bullet points, or markdown.
+"""
+
+    try:
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.chat.completions.create(
+            model="gpt-4.1-mini",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You summarize a news outlet's coverage using only the provided article text.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            temperature=0.3,
+        )
+        summary = response.choices[0].message.content
+        if not summary:
+            raise ValueError("The generated summary was empty.")
+        return {"summary": summary.strip()}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from search import filter_articles
 from users import router as users_router
 from compare import router as compare_router
 from bias import router as bias_router
+from channel_summary import router as channel_summary_router
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(HERE, "..", "data")
@@ -35,6 +36,7 @@ app.add_middleware(
 app.include_router(users_router)
 app.include_router(compare_router)
 app.include_router(bias_router)
+app.include_router(channel_summary_router)
 
 @app.get("/api/ready")
 def api_ready():

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,8 +20,8 @@ For UI. Display timeline
 **Timeline**  
 Default view. Articles are grouped by date in chronological columns. Up to 5 articles are shown per day, ranked by source credibility and cross-outlet coverage. Hovering shows a summary tooltip, and clicking a source name highlights only that source across the timeline.
 
-**Channels**  
-Grid of news source cards. Clicking a source shows all of its articles grouped by date.
+**Channels**
+Grid of news source cards. Clicking a source requests an AI-generated overview of its loaded articles and shows the articles grouped by date.
 
 **LLM**  
 Collapsible cards showing AI-generated summaries, such as ChatGPT and Gemini, with political leaning. Currently hardcoded.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -912,15 +912,69 @@ function showChannelsGrid() {
   document.getElementById("channels-detail").classList.remove("active");
 }
 
-const CHANNEL_ANALYSIS = {
-  "New York Times": `The New York Times covered the Trump–Pope Leo dispute primarily as a domestic political story rather than a religious one, with most reporting filed by White House and politics correspondents. The arc unfolds across two days:
+const channelSummaryCache = new Map();
 
-<strong>April 13 — Trigger and response.</strong> Coverage opens with Katie Rogers framing Trump's Truth Social attack as showing "no boundaries" on whom the president will target, setting an editorially critical tone from the start. The story expands across multiple fronts the same day: the Pope's restrained pushback from his plane to Algeria, reported sympathetically by Motoko Rich, and Trump's AI-generated Jesus image, which drew bipartisan Catholic backlash that NYT amplified through extensive quotes from bishops, the U.S. Conference of Catholic Bishops, and even Trump-aligned figures like Bishop Robert Barron.
-<strong>April 14 — Political fallout.</strong> The frame shifts decisively to electoral math: Lerer and Epstein cast the feud as a GOP "headache" threatening Catholic swing voters in Michigan, Ohio, Wisconsin, and South Texas, while VP Vance's Fox News defense telling the Vatican to "stick to matters of morality" is covered as administration damage control.
+function renderChannelSummaryPanel(analysisBox, src) {
+  analysisBox.innerHTML = "";
 
-Across all five articles, NYT consistently centers political consequences and Catholic institutional reaction, with less prominent attention to the theological substance of Leo's anti-war message itself.
-`,
-};
+  const eyebrow = document.createElement("div");
+  eyebrow.className = "channel-analysis-eyebrow";
+  eyebrow.textContent = "AI Channel Summary";
+
+  const heading = document.createElement("h4");
+  heading.className = "channel-analysis-heading";
+  heading.textContent = `${src} coverage overview`;
+
+  const body = document.createElement("p");
+  body.className = "channel-analysis-body";
+
+  analysisBox.append(eyebrow, heading, body);
+  return body;
+}
+
+async function loadChannelSummary(src, articles, analysisBox, summaryBody) {
+  if (!articles.length) {
+    summaryBody.textContent = `No articles are currently loaded for ${src}.`;
+    return;
+  }
+
+  if (channelSummaryCache.has(src)) {
+    summaryBody.textContent = channelSummaryCache.get(src);
+    return;
+  }
+
+  analysisBox.classList.add("loading");
+  summaryBody.textContent = "Generating summary...";
+
+  try {
+    const response = await fetch("/api/channel-summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source: src,
+        articles: articles.map(article => ({
+          title: article.title,
+          summary: article.summary,
+          date: article.isoDate,
+        })),
+      }),
+    });
+    if (!response.ok) throw new Error("Could not generate the channel summary.");
+
+    const data = await response.json();
+    channelSummaryCache.set(src, data.summary);
+    if (document.getElementById("channel-name").textContent === src) {
+      summaryBody.textContent = data.summary;
+    }
+  } catch (error) {
+    console.error("Could not load channel summary:", error);
+    if (document.getElementById("channel-name").textContent === src) {
+      summaryBody.textContent = "Could not generate this channel summary. Please try again.";
+    }
+  } finally {
+    analysisBox.classList.remove("loading");
+  }
+}
 
 function showChannelDetail(src) {
   document.getElementById("channels-grid").classList.remove("active");
@@ -928,12 +982,9 @@ function showChannelDetail(src) {
   document.getElementById("channel-name").textContent = src;
 
   const analysisBox = document.getElementById("channel-analysis-box");
-  if (CHANNEL_ANALYSIS[src]) {
-    analysisBox.innerHTML = CHANNEL_ANALYSIS[src];
-    analysisBox.style.display = "block";
-  } else {
-    analysisBox.style.display = "none";
-  }
+  analysisBox.style.display = "block";
+  const summaryBody = renderChannelSummaryPanel(analysisBox, src);
+  loadChannelSummary(src, channelData[src] || [], analysisBox, summaryBody);
 
   const wrap = document.getElementById("channel-timeline");
   wrap.innerHTML = "";
@@ -1661,6 +1712,7 @@ async function loadAndRender(query, prefetchedArticles) {
     timelineData = toTimelineData(normalized);
     channelData = toChannelData(normalized);
     clusterData = toClusterData(normalized);
+    channelSummaryCache.clear();
 
     const sources = Object.keys(channelData).sort();
     assignSourceColors(sources);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1373,18 +1373,52 @@ body {
 
 /* ── CHANNEL ANALYSIS BOX ─────────────────────────────── */
 .channel-analysis-box {
-  margin: 14px 0 22px;
-  padding: 18px 22px;
-  background: var(--slate-50);
-  border-left: 3px solid var(--accent);
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.75;
+  margin: 16px 0 24px;
+  padding: 18px 22px 20px;
+  background: var(--white);
+  border: 1px solid var(--slate-200);
+  border-left: 4px solid var(--accent);
+  border-radius: 6px;
   color: var(--navy-900);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.channel-analysis-box.loading {
+  border-left-color: var(--slate-400);
+  box-shadow: none;
+}
+
+.channel-analysis-eyebrow {
+  margin-bottom: 5px;
+  color: var(--accent-dark);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.channel-analysis-heading {
+  margin: 0;
+  color: var(--navy-900);
+  font-size: 16px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.channel-analysis-body {
+  max-width: 920px;
+  margin: 10px 0 0;
+  color: var(--slate-600);
+  font-size: 14px;
+  line-height: 1.75;
   white-space: pre-wrap;
 }
 
-.channel-analysis-box strong { font-weight: 700; }
+.channel-analysis-box.loading .channel-analysis-body {
+  color: var(--slate-400);
+  font-style: italic;
+}
 
 /* ── RESPONSIVE ───────────────────────────────────────── */
 @media (max-width: 1100px) {


### PR DESCRIPTION
Adds AI-generated summaries to the Channels tab.

- Replaces the hardcoded New York Times writeup with a dynamic summary for every channel.
- Adds a backend `/api/channel-summary` endpoint using OpenAI.
- Generates summaries only when a channel is clicked.
- Caches generated summaries during the current page session.
- Adds loading and error states.