### PR TITLE
Add search page bypass option

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -168,6 +168,7 @@ let currentQuery = null;
 const landingEl            = document.getElementById("landing");
 const landingInput         = document.getElementById("landing-input");
 const landingBtn           = document.getElementById("landing-btn");
+const landingBypassBtn     = document.getElementById("landing-bypass-btn");
 const landingStatus        = document.getElementById("landing-status");
 const landingProgress      = document.getElementById("landing-progress");
 const landingProgressFill  = document.getElementById("landing-progress-fill");
@@ -257,11 +258,28 @@ function stopProgressPolling() {
   if (animationFrame)  { cancelAnimationFrame(animationFrame); animationFrame = null; }
 }
 
+function updateLandingBypassLabel() {
+  landingBypassBtn.textContent = timelineData.length
+    ? "Return Without Searching"
+    : "Continue Without Search";
+}
+
 landingBtn.addEventListener("click", triggerSearch);
+landingBypassBtn.addEventListener("click", () => {
+  landingStatus.hidden = true;
+  landingProgress.hidden = true;
+  if (!timelineData.length) {
+    currentQuery = null;
+    sessionStorage.removeItem("lastSearch");
+    setStoryHeadline("No Search Selected");
+  }
+  landingEl.classList.add("hidden");
+});
 landingInput.addEventListener("keydown", (e) => { if (e.key === "Enter") triggerSearch(); });
 
 document.getElementById("new-search-btn").addEventListener("click", () => {
   sessionStorage.removeItem("lastSearch");
+  updateLandingBypassLabel();
   landingEl.classList.remove("hidden");
   landingStatus.hidden = true;
   landingBtn.disabled = false;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,6 +27,7 @@
         <input id="landing-input" type="text" placeholder='Try "Trump Pope Leo" or "Gaza ceasefire"...' autocomplete="off" />
       </div>
       <button id="landing-btn" class="landing-btn">Track This Story →</button>
+      <button id="landing-bypass-btn" class="landing-bypass-btn">Continue Without Search</button>
       <p class="landing-hint">Pulls the latest articles from NYT, NewsAPI, and more.</p>
 
       <div id="landing-status" class="landing-status" hidden></div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -134,6 +134,27 @@
   transform: none;
 }
 
+.landing-bypass-btn {
+  width: 100%;
+  margin: -2px 0 14px;
+  padding: 11px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.78);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.landing-bypass-btn:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
 .landing-hint {
   margin: 0;
   font-size: 12px;


### PR DESCRIPTION
Adds an option to enter or return to the app without running a new search.

- Adds a button on the landing page: shows `Continue Without Search` when no articles are loaded and `Return Without Searching` after a previous search.
- Preserves previously loaded articles when returning.
