### PR TITLE
Add dynamic LLM analysis pipeline and timeline AI Sources row

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,6 @@ CURRENT_API=your_current_api_key_here
 CURRENT_URL=https://api.currentsapi.services/v1/search
 
 # LLMs
-OPENAI_API_KEY=your_opoen_ai_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+GOOGLE_API_KEY=your_google_api_key_here

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Frontend for the user-facing web application.
 Backend for the user-facing web application. 
 
 ### `webscraper/`
-This directory will contain the automated data ingestion and NLP analysis pipelines.
+Automated data ingestion pipeline. Fetches news articles from NewsAPI, NYT, and Currents API, normalizes them into a common format, and saves results to `data/`.
 
 ### `data_analysis_nlp/`
+NLP analysis scripts for source bias clustering, sentiment analysis, and text statistics.
 
 ### `data_analysis_llms/`
+LLM-based article analysis pipeline using NVIDIA Nemotron. Produces structured per-article analysis (claims, framing, stakeholders) cached in `data/llm_analysis.json`.
 
 ### `visualizations/`
 Visualizations from experiments 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,32 +1,38 @@
 ## `backend/`
 
-FastAPI backend serving article search, user profiles, and KPI telemetry. Runs on Python 3.12+ via Poetry.
+FastAPI backend serving article search, user profiles, KPI telemetry, and LLM analysis. Runs on Python 3.12+ via uv.
 
 ---
 
 ## Files
 
-
-| File              | Description                                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main.py`         | FastAPI app entry point. Registers routers, CORS middleware, and pre-warms the BM25 index on startup via the lifespan hook.                               |
-| `search.py`       | BM25 article search. Loads `data/articles.json` on startup and re-indexes whenever the file changes (mtime check per request). Exposes `GET /api/search`. |
-| `users.py`        | User profiles and event telemetry. Reads/writes Redis. Exposes `POST /api/users`, `GET /api/users/{id}`, `POST /api/events`.                              |
-| `redis_client.py` | Async Redis singleton. Reads `REDIS_URL` from the environment; defaults to `redis://localhost:6379`.                                                      |
-
+| File                  | Description                                                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.py`             | FastAPI app entry point. Registers routers, CORS middleware, and pre-warms the search cache on startup.                                                   |
+| `search.py`           | BM25 article search. Loads `data/articles.json` on startup and re-indexes whenever the file changes (mtime check per request). Exposes `GET /api/search`. |
+| `users.py`            | User profiles and event telemetry. Reads/writes Supabase. Exposes `POST /api/users`, `GET /api/users/{id}`, `POST /api/events`.                          |
+| `supabase_client.py`  | Supabase singleton. Reads `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` from the environment.                                                                 |
+| `llm_summary.py`      | LLM analysis pipeline. Queries ChatGPT, Gemini, and Claude in parallel (each with web search grounding), then runs a meta-analysis step with the same model. Results are cached to `data/llm_summaries/` with a 24-hour TTL. Exposes `GET /api/llm-summary`. |
+| `compare.py`          | Article comparison. Accepts 2–3 articles and returns an AI-generated side-by-side analysis. Exposes `POST /api/compare`.                                 |
+| `channel_summary.py`  | Source coverage summary. Accepts a list of articles from one outlet and returns an AI-generated overview. Exposes `POST /api/channel-summary`.           |
+| `bias.py`             | Serves precomputed per-article bias scores from `data/`. Exposes `GET /api/bias`.                                                                        |
 
 ---
 
 ## Running locally
 
-**Prerequisites:** Redis running locally (`brew install redis && brew services start redis`).
-
 ```bash
-# from backend dir
-DATA_PATH=data/articles.json poetry run uvicorn main:app --port 8001 --reload
+# from repo root
+uv run uvicorn backend.main:app --port 8000 --reload
 ```
 
-Interactive API docs: `http://localhost:8001/docs`
+Or from the `backend/` directory:
+
+```bash
+uv run uvicorn main:app --port 8000 --reload
+```
+
+Interactive API docs: `http://localhost:8000/docs`
 
 ---
 
@@ -34,7 +40,7 @@ Interactive API docs: `http://localhost:8001/docs`
 
 ### `GET /api/search`
 
-BM25 keyword search over local articles. Results include a `score` field normalized to [0, 1]; articles scoring below 0.1 are omitted.
+BM25 keyword search over local articles. Triggers the webscraper for the given query if results are not cached. Results include a `score` field normalized to [0, 1].
 
 ```
 GET /api/search?q=trump+pope&limit=5
@@ -52,6 +58,32 @@ GET /api/search?q=trump+pope&limit=5
       "author": "...",
       "source": "cnn.com",
       "score": 0.97
+    }
+  ]
+}
+```
+
+### `GET /api/llm-summary`
+
+Queries ChatGPT (`gpt-5.4-mini`), Gemini (`gemini-3.5-flash`), and Claude (`claude-haiku-4-5`) about the given topic in parallel. Each LLM uses web search grounding for step 1 and its own model for the meta-analysis in step 2. Results are cached to `data/llm_summaries/` for 24 hours.
+
+```
+GET /api/llm-summary?q=trump+pope
+```
+
+```json
+{
+  "query": "trump pope",
+  "generated_at": "2026-05-31T12:00:00Z",
+  "llms": [
+    {
+      "name": "ChatGPT",
+      "model": "gpt-5.4-mini",
+      "color": "#10a37f",
+      "raw_response": "...",
+      "summary": "...",
+      "biases": [{ "title": "Framing Bias", "body": "..." }],
+      "sources": [{ "label": "cnn.com — Title", "url": "https://..." }]
     }
   ]
 }
@@ -108,6 +140,10 @@ Record a user action. Fire-and-forget — the frontend does not need to await or
 `search` payload: `{ "query": "..." }`.  
 Returns `204 No Content`.
 
+### `POST /api/compare`
+
+Compare 2–3 articles and return an AI-generated side-by-side analysis. Requires `OPENAI_API_KEY`.
+
 ### `POST /api/channel-summary`
 
 Generate a short AI overview of one source's loaded articles. Requires `OPENAI_API_KEY`.
@@ -116,11 +152,7 @@ Generate a short AI overview of one source's loaded articles. Requires `OPENAI_A
 {
   "source": "New York Times",
   "articles": [
-    {
-      "title": "...",
-      "summary": "...",
-      "date": "2026-05-30"
-    }
+    { "title": "...", "summary": "...", "date": "2026-05-30" }
   ]
 }
 ```
@@ -129,12 +161,12 @@ Generate a short AI overview of one source's loaded articles. Requires `OPENAI_A
 
 ## Environment variables
 
+| Variable              | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `SUPABASE_URL`        | Supabase project URL                                         |
+| `SUPABASE_SERVICE_KEY`| Supabase service role key (server-side only)                 |
+| `OPENAI_API_KEY`      | Used for search grounding, article comparison, and channel summaries |
+| `ANTHROPIC_API_KEY`   | Used for Claude LLM analysis                                 |
+| `GOOGLE_API_KEY`      | Used for Gemini LLM analysis                                 |
 
-| Variable    | Default                  | Description               |
-| ----------- | ------------------------ | ------------------------- |
-| `REDIS_URL` | `redis://localhost:6379` | Redis connection string   |
-| `DATA_PATH` | `data/articles.json`     | Path to article JSON file |
-| `OPENAI_API_KEY` | — | OpenAI API key used for article comparisons and channel summaries |
-
-
-Add both to `.env` (see `.env.example`). For Vercel, provision Upstash Redis from the Marketplace and set `REDIS_URL` in project settings.
+See `.env.example` at the repo root.

--- a/backend/llm_summary.py
+++ b/backend/llm_summary.py
@@ -1,0 +1,194 @@
+import concurrent.futures
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+import anthropic
+from fastapi import APIRouter, HTTPException, Query
+from google import genai
+from google.genai import types as genai_types
+from openai import OpenAI
+
+router = APIRouter()
+
+LLM_CONFIGS = [
+    {"name": "ChatGPT", "color": "#10a37f", "model": "gpt-5.4-mini"},
+    {"name": "Gemini",  "color": "#4285f4", "model": "gemini-3.5-flash"},
+    {"name": "Claude",  "color": "#cc785c", "model": "claude-haiku-4-5"},
+]
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CACHE_DIR = os.path.join(HERE, "..", "data", "llm_summaries")
+CACHE_TTL_HOURS = 24
+
+_SUMMARY_PROMPT = "Summarize the latest news about: {query}. Cite your sources with URLs."
+
+_ANALYSIS_SYSTEM = (
+    "You are an analyst extracting structured data from an AI chatbot's news response. "
+    "Return valid JSON only with exactly these keys:\n"
+    '- "summary": string, 2-3 sentences characterizing how this LLM told the story '
+    "(neutral meta-analysis of framing, not a re-summary of events)\n"
+    '- "biases": array of {{"title": string, "body": string}}, 2-4 specific bias findings '
+    "(framing bias, omission bias, source bias, etc.)\n"
+    '- "sources": array of {{"label": string, "url": string}}, every URL cited in the response '
+    'formatted as "domain.com — anchor text"\n'
+    "Do not include any text outside the JSON object."
+)
+
+
+def _slug(query: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", query.lower()).strip("_")
+
+
+def _cache_path(query: str) -> str:
+    return os.path.join(CACHE_DIR, f"{_slug(query)}.json")
+
+
+def _load_cache(query: str) -> dict | None:
+    path = _cache_path(query)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        generated_at = datetime.fromisoformat(data["generated_at"])
+        if datetime.now(timezone.utc) - generated_at > timedelta(hours=CACHE_TTL_HOURS):
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def _write_cache(data: dict) -> None:
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    path = _cache_path(data["query"])
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def _extract_json(text: str) -> dict:
+    text = re.sub(r"^```(?:json)?\s*", "", text.strip())
+    text = re.sub(r"\s*```$", "", text.strip())
+    return json.loads(text)
+
+
+# ── Step 1: web-grounded queries ───────────────────────────
+
+def _query_openai(query: str, model: str) -> str:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    resp = client.responses.create(
+        model=model,
+        tools=[{"type": "web_search_preview"}],
+        input=_SUMMARY_PROMPT.format(query=query),
+    )
+    return resp.output_text
+
+
+def _query_gemini(query: str, model: str) -> str:
+    client = genai.Client(api_key=os.getenv("GOOGLE_API_KEY"))
+    resp = client.models.generate_content(
+        model=model,
+        contents=_SUMMARY_PROMPT.format(query=query),
+        config=genai_types.GenerateContentConfig(
+            tools=[genai_types.Tool(google_search=genai_types.GoogleSearch())],
+        ),
+    )
+    return resp.text
+
+
+def _query_claude(query: str, model: str) -> str:
+    client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    resp = client.messages.create(
+        model=model,
+        max_tokens=2048,
+        tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 5}],
+        messages=[{"role": "user", "content": _SUMMARY_PROMPT.format(query=query)}],
+    )
+    return "\n\n".join(block.text for block in resp.content if hasattr(block, "text"))
+
+
+# ── Step 2: meta-analysis using the same model ─────────────
+
+def _analyze_openai(query: str, raw: str, model: str) -> dict:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    resp = client.chat.completions.create(
+        model=model,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": _ANALYSIS_SYSTEM},
+            {"role": "user", "content": f"News topic: {query}\n\nLLM response to analyze:\n{raw}"},
+        ],
+        temperature=0.2,
+    )
+    return json.loads(resp.choices[0].message.content)
+
+
+def _analyze_gemini(query: str, raw: str, model: str) -> dict:
+    client = genai.Client(api_key=os.getenv("GOOGLE_API_KEY"))
+    resp = client.models.generate_content(
+        model=model,
+        contents=f"{_ANALYSIS_SYSTEM}\n\nNews topic: {query}\n\nLLM response to analyze:\n{raw}",
+        config=genai_types.GenerateContentConfig(
+            response_mime_type="application/json",
+        ),
+    )
+    return _extract_json(resp.text)
+
+
+def _analyze_claude(query: str, raw: str, model: str) -> dict:
+    client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    resp = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=_ANALYSIS_SYSTEM,
+        messages=[{"role": "user", "content": f"News topic: {query}\n\nLLM response to analyze:\n{raw}"}],
+    )
+    text = "\n\n".join(block.text for block in resp.content if hasattr(block, "text"))
+    return _extract_json(text)
+
+
+_QUERY_FN    = {"ChatGPT": _query_openai,   "Gemini": _query_gemini,   "Claude": _query_claude}
+_ANALYZE_FN  = {"ChatGPT": _analyze_openai, "Gemini": _analyze_gemini, "Claude": _analyze_claude}
+
+
+def _process_llm(cfg: dict, query: str) -> dict:
+    raw_response = _QUERY_FN[cfg["name"]](query, cfg["model"])
+    extracted    = _ANALYZE_FN[cfg["name"]](query, raw_response, cfg["model"])
+    return {
+        "name":         cfg["name"],
+        "model":        cfg["model"],
+        "color":        cfg["color"],
+        "raw_response": raw_response,
+        "summary":      extracted.get("summary", ""),
+        "biases":       extracted.get("biases", []),
+        "sources":      extracted.get("sources", []),
+    }
+
+
+def _run_pipeline(query: str) -> dict:
+    order = {cfg["name"]: i for i, cfg in enumerate(LLM_CONFIGS)}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(LLM_CONFIGS)) as pool:
+        futures = {pool.submit(_process_llm, cfg, query): cfg for cfg in LLM_CONFIGS}
+        llm_results = [f.result() for f in concurrent.futures.as_completed(futures)]
+    llm_results.sort(key=lambda x: order.get(x["name"], 99))
+
+    result = {
+        "query":        query,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "llms":         llm_results,
+    }
+    _write_cache(result)
+    return result
+
+
+@router.get("/api/llm-summary")
+async def get_llm_summary(q: str = Query(..., min_length=1)):
+    query = q.strip()
+    cached = _load_cache(query)
+    if cached:
+        return cached
+    try:
+        return _run_pipeline(query)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from users import router as users_router
 from compare import router as compare_router
 from bias import router as bias_router
 from channel_summary import router as channel_summary_router
+from llm_summary import router as llm_summary_router
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(HERE, "..", "data")
@@ -123,6 +124,7 @@ app.include_router(users_router)
 app.include_router(compare_router)
 app.include_router(bias_router)
 app.include_router(channel_summary_router)
+app.include_router(llm_summary_router)
 
 @app.on_event("startup")
 async def prewarm_cache():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,8 @@ fastapi>=0.136.1
 uvicorn[standard]>=0.46.0
 python-dotenv
 openai>=1.82.0
+anthropic>=0.105.2
+google-genai>=2.7.0
 rank-bm25>=0.2.2
 supabase>=2.0.0
 requests>=2.33.1

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,58 +1,62 @@
 ## `frontend/`
 
-For UI. Display timeline
+Vanilla JS single-page application for the user-facing web app. Served as static files by the FastAPI backend.
 
 ---
 
 ### Files
 
-| File | Description |
-|---|---|
-| `index.html` | App shell — defines the three views: Timeline, Channels, LLM, and the compare modal |
-| `app.js` | All application logic — data loading, transformation, rendering, and interaction |
-| `styles.css` | Styling using CSS variables; responsive breakpoint at 1100px |
-| `frontend_data.json` | Static sample data, not used at runtime. The app loads from `../data/articles.json` |
+| File          | Description                                                                                          |
+|---------------|------------------------------------------------------------------------------------------------------|
+| `index.html`  | App shell — defines the views: Timeline, Channels, Story Clusters, LLM Analysis, and Account        |
+| `app.js`      | All application logic — data loading, transformation, rendering, and interaction                     |
+| `styles.css`  | Styling using CSS variables; responsive breakpoint at 1100px                                         |
 
 ---
 
 ### Views
 
 **Timeline**  
-Default view. Articles are grouped by date in chronological columns. Up to 5 articles are shown per day, ranked by source credibility and cross-outlet coverage. Hovering shows a summary tooltip, and clicking a source name highlights only that source across the timeline.
+Default view. Articles are grouped by date in chronological columns. Up to 5 articles are shown per day, ranked by source credibility and cross-outlet coverage. Hovering shows a summary tooltip, clicking a source name highlights only that source across the timeline. A pinned **AI Sources** row above the columns shows a card per LLM (ChatGPT, Gemini, Claude) — clicking any card navigates to the LLM Analysis view.
 
-**Channels**
+**Channels**  
 Grid of news source cards. Clicking a source requests an AI-generated overview of its loaded articles and shows the articles grouped by date.
 
-**LLM**  
-Collapsible cards showing AI-generated summaries, such as ChatGPT and Gemini, with political leaning. Currently hardcoded.
+**Story Clusters**  
+Articles grouped by semantic similarity using HDBSCAN clustering.
+
+**LLM Analysis**  
+One collapsible card per LLM (ChatGPT, Gemini, Claude). Each card shows a meta-analysis summary, a numbered list of bias findings, a cited sources list, and a **Full Response** sub-toggle that renders the LLM's raw web-grounded response as formatted markdown. Data is fetched dynamically from `GET /api/llm-summary` on search and cached for 24 hours.
+
+**Account**  
+User profile, session KPIs, search history, and a blind-spot panel showing articles from the political leaning the user has read least.
 
 ---
 
 ### Filters: Timeline View
 
-| Filter | Description |
-|---|---|
-| Source checkboxes | Show or hide individual outlets; includes All/None toggles |
-| Date range | Restrict the timeline to a start and end date |
-| Political leaning slider | UI only — not yet wired up |
+| Filter                   | Description                                                              |
+|--------------------------|--------------------------------------------------------------------------|
+| Source checkboxes        | Show or hide individual outlets; includes All/None toggles               |
+| Date range               | Restrict the timeline to a start and end date                            |
+| Political leaning slider | Filter articles by left/right lean and intensity                         |
 
 ---
 
 ### Data Flow
 
 ```text
-data/articles.json
-        ↓
-init() in app.js
-        ↓
-toTimelineData()  →  renderTimeline()
-toChannelData()   →  buildChannelCards()
-'''
-`app.js` fetches article data from `../data/articles.json` when the page loads. If `articles.json` is missing or stale, run:
-
-```bash
-python webscraper/refresh.py
+/api/search?q=...          /api/llm-summary?q=...
+      ↓                              ↓
+loadAndRender()              loadLLMData()  (parallel, no await)
+      ↓                              ↓
+toTimelineData()            llmSummaryData
+toChannelData()                      ↓
+      ↓                    renderLLM() / renderAISources()
+renderTimeline()
 ```
+
+On search, both the article search and LLM pipeline are fired in parallel. Article results render immediately; LLM cards show a loading state until the pipeline completes (~15s).
 
 ---
 
@@ -60,46 +64,27 @@ python webscraper/refresh.py
 
 Articles are ranked using the following source credibility tiers:
 
-| Tier | Sources |
-|---|---|
-| Tier 3, highest | NYT, Reuters, AP, BBC, NPR, PBS, The Guardian, Washington Post |
-| Tier 2 | The Atlantic, Politico, Axios, The Hill, CNN, ABC, NBC, CBS |
-| Tier 1, default | Everything else |
+| Tier              | Sources                                                                          |
+|-------------------|----------------------------------------------------------------------------------|
+| Tier 3, highest   | NYT, Reuters, AP, BBC, NPR, PBS, The Guardian, Washington Post                   |
+| Tier 2            | The Atlantic, Politico, Axios, The Hill, CNN, ABC, NBC, CBS                      |
+| Tier 1, default   | Everything else                                                                  |
 
 ---
-## Article Comparison (Demo)
 
-A temporary demo feature allows users to compare two or three articles.
+### Article Comparison
 
-- Click "COMPARE" in the timeline view
-- Select 2-3 articles from the timeline
-- Click "Compare Articles" in the pop-up modal
-- View side-by-side summaries including sources, core arguments, and key points.
+Click **Article Comparison** in the timeline view, select 2–3 articles, then click **Compare Articles** to view an AI-generated side-by-side analysis (sources, core arguments, key points). Results are generated by `POST /api/compare`.
 
-The comparison results are generated by the backend LLM endpoint.
-
-___
+---
 
 ### Running
 
-Before running the frontend, make sure the article data has been generated:
+The frontend is served by the FastAPI backend — no separate server needed:
 
 ```bash
-python webscraper/refresh.py
+# from repo root
+uv run uvicorn backend.main:app --port 8000 --reload
 ```
 
-Then start a local server from the repo root:
-
-```bash
-python -m http.server 8080
-```
-
-Open the frontend in your browser:
-
-```text
-http://localhost:8080/frontend/
-```
-
-
-
-
+Then open `http://localhost:8000`.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -362,6 +362,7 @@ async function triggerSearch() {
   landingBtn.disabled = true;
   showLandingStatus("Fetching articles… this may take up to 1 minute.");
   startProgressPolling();
+  loadLLMData(query); // fire in parallel, no await
 
   try {
     await runSearchQuery(query);
@@ -724,12 +725,20 @@ function setView(name) {
   if (name === "channels") showChannelsGrid();
   if (name === "clusters") renderStoryClusters();
   if (name === "account") renderAccountView();
+  if (name === "llm") {
+    if (currentQuery && !llmSummaryData && !llmSummaryLoading) {
+      loadLLMData(currentQuery);
+    } else {
+      renderLLM();
+    }
+  }
 }
 
 // ---------- Timeline rendering ----------
 
 function renderTimeline() {
   clearTimelineSourceSelection();
+  renderAISources();
   const filtered = getFilteredTimelineData();
   timelineColumnsEl.innerHTML = "";
   if (!filtered.length) {
@@ -1162,124 +1171,88 @@ function renderStoryClusters() {
 
 // ---------- LLM view ----------
 
-const llmData = [
-  {
-    name: "ChatGPT",
-    color: "#10a37f",
-    url: "https://chatgpt.com/s/t_69efdcf511d08191b5fa81803342b111",
-    summary: "A dramatized, narrative-heavy account that frames the feud as a major ideological clash between nationalism and global humanitarianism. It consistently favors Leo's position through asymmetric language and relies on a narrow set of center-left sources. The least factually precise of the three, with editorial bias baked into its structure and framing.",
-    biases: [
-      {
-        title: "Political / Framing Bias (Pro-Pope)",
-        body: `The response consistently frames Trump's positions with charged language (“hardline,” “personal attacks,” “unusually blunt”) while describing the pope's stances in neutral or positive terms (“moral restraint,” “peace,” “humanitarian focus”). This is asymmetric framing. Notably, the response omits that religion experts described the pope's words as “quite banal” and “the status quo of Catholic social teachings” — framing Leo as more of a reformer than he may actually be. It also omits Trump's specific, substantive criticisms (e.g., concerns about Iran's nuclear ambitions), which are present in the original source material.`,
-      },
-      {
-        title: "Source Bias",
-        body: "The response cites CBS News, Reuters, and Boston.com — all centrist-to-left-leaning outlets — with no counterbalancing sources from right-leaning media. This creates a one-sided evidentiary base. For example, polling data showing Trump's approval among Catholic voters actually rebounded during the feud is entirely absent, which would have complicated the narrative that Trump's attacks are broadly damaging.",
-      },
-      {
-        title: "False Equivalence / Asymmetry Bias",
-        body: `The response labels this a mutual “conflict” and “feud,” but one religion expert described it as a “one-way feud,” with Trump berating a critic. Calling it a two-sided clash inflates the pope's aggressiveness in the exchange.`,
-      },
-      {
-        title: "Omission Bias (Temporal)",
-        body: `The response presents the feud's origins somewhat loosely. The actual catalytic event was Operation Epic Fury, a joint U.S.-Israeli military operation beginning February 28, 2026 — a specific detail the chatbot omits, replacing it with vaguer language about a “2026 conflict involving Iran.” This obscures the timeline and reduces factual precision.`,
-      },
-      {
-        title: "Editorial / Structural Bias",
-        body: `The use of emoji headers (🔥⚔️🧠🌍🧩) and dramatic section labels like “What sparked the dispute” and “Main points of conflict” imposes a narrative arc that subtly dramatizes the story and primes the reader to see it as a significant moral clash rather than a political disagreement.`,
-      },
-    ],
-    sources: [
-      { label: "cbsnews.com — Trump-Pope Leo feud politics", url: "https://www.cbsnews.com/news/trump-pope-leo-feud-politics/" },
-      { label: "reuters.com — Pope Leo decries migrants", url: "https://www.reuters.com/world/pope-leo-decries-migrants-being-treated-worse-than-house-pets-2026-04-23/" },
-      { label: "boston.com — Trump lambasts Pope Leo XIV", url: "https://www.boston.com/news/politics/2026/04/12/trump-lambasts-pope-leo-xiv-extending-feud-over-iran-war-with-first-american-pontiff/" },
-      { label: "cbsnews.com — How dispute escalated", url: "https://www.cbsnews.com/news/how-dispute-trump-pope-leo-escalated/" },
-    ],
-  },
-  {
-    name: "Perplexity",
-    color: "#6e57e0",
-    url: "https://www.perplexity.ai/search/98d83dc7-a3f4-449f-a15b-e7a4b5acd894",
-    summary: "A clean, plain-prose account that presents both sides' positions without heavy editorializing or dramatic framing. Its weaknesses are mostly sins of omission — particularly missing polling data — and vague sourcing with no inline citations. Reads like a competent news brief but lacks the depth to fully contextualize the story.",
-    biases: [
-      {
-        title: "Framing Bias (Mild, Against Trump)",
-        body: `Trump “attacked” the pope, while Leo “took the stance” — subtly casting Trump as aggressor and Leo as principled respondent. Similarly, describing Leo as “defiant” carries a mildly heroic connotation that isn't balanced by an equivalently characterful word for Trump's persistence. The language is mostly even, but these small asymmetries add up.`,
-      },
-      {
-        title: "Omission Bias (Pope Leo's sharpening rhetoric)",
-        body: `The response describes Leo as speaking “from a moral and gospel-based perspective, not as a partisan politician” — but omits that the pope's own language sharpened over time, escalating from prayers for peace to calling the war “unjust” and labeling Trump's threat to destroy Iranian civilization “truly unacceptable.” Leaving this out makes Leo appear more passive and measured than the record shows.`,
-      },
-      {
-        title: "Source Bias (Implicit)",
-        body: `The response cites no sources at all, making it impossible to evaluate where the claims originate. The characterization that Leo has been “defiant and unwilling to back down” is attributed only vaguely to “reports” — a weak attribution that obscures potential editorial slant in the underlying sources.`,
-      },
-      {
-        title: "Omission Bias (Catholic polling data)",
-        body: `The “Why it matters” section says the feud has created “political fallout on the right,” implying Trump has been politically damaged. But polling data shows Trump's approval among Catholic voters actually rebounded in April despite the feud intensifying — a significant fact that contradicts the implied narrative of political cost.`,
-      },
-      {
-        title: "Temporal / Factual Vagueness",
-        body: "Like ChatGPT, this response never names the specific triggering event. Operation Epic Fury — the joint U.S.-Israeli military strike on Iran beginning February 28, 2026 — was the direct catalyst, and omitting it leaves the timeline fuzzy and harder to fact-check.",
-      },
-    ],
-    sources: [
-      { label: "youtube.com — PBS News Hour", url: "https://www.youtube.com/watch?v=Vt2l9sujNTk" },
-      { label: "nytimes.com — Republicans, Trump, Pope midterms", url: "https://www.nytimes.com/2026/04/17/us/politics/republicans-trump-pope-midterms.html" },
-      { label: "bbc.com — Trump-Pope Leo coverage", url: "https://www.bbc.com/news/articles/c070jxyjrmeo" },
-      { label: "pbs.org — Trump clashes with Pope Leo", url: "https://www.pbs.org/newshour/show/trump-clashes-with-pope-leo-who-vows-to-continue-speaking-out-against-war" },
-      { label: "npr.org — American Catholics in awkward spot", url: "https://www.npr.org/2026/04/18/nx-s1-5788718/tensions-between-president-trump-and-pope-leo-put-american-catholics-in-awkward-spot" },
-      { label: "cbsnews.com — Trump-Pope Leo feud politics", url: "https://www.cbsnews.com/news/trump-pope-leo-feud-politics/" },
-    ],
-  },
-  {
-    name: "Gemini",
-    color: "#4285f4",
-    url: "https://gemini.google.com/app/8adea3eab974b7d2",
-    summary: "A well-structured account that correctly names the triggering event and provides a useful comparison table of both positions. It contains one potentially hallucinated specific claim about an AI-generated image, and mildly favors Leo through subtle language choices. High-variance: well-organized and detailed but carries reliability risks from unverified specifics.",
-    biases: [
-      {
-        title: "Sensationalism / Hyperbole Bias",
-        body: `Calling this “one of the most high-profile diplomatic rifts in modern history” is unsupported editorializing. It overstates the significance of what religion experts have described as fairly routine papal behavior — “quite banal” and “the status quo of Catholic social teachings.”`,
-      },
-      {
-        title: "Fabrication Risk / Unverified Claim",
-        body: `The response mentions Trump sharing an AI-generated image depicting himself as Jesus-like, which “many Catholic leaders and the Vatican viewed as sacrilegious.” This specific claim does not appear in any of the verified sources reviewed. It may be accurate, but its inclusion without a citation in a context with other verifiable facts is a red flag for hallucination or embellishment.`,
-      },
-      {
-        title: "Framing Bias (Subtle, Pro-Leo)",
-        body: `The summary table is structurally fair, but the language choices favor Leo. His position on military action is described as “advocacy for non-violent resolution and 'just war' doctrine” — a sophisticated, theologically grounded framing — while Trump's is simply “necessary for global stability and ending nuclear threats,” which sounds blunter by comparison.`,
-      },
-      {
-        title: "Omission Bias (Catholic public opinion)",
-        body: "Like the previous two responses, this one omits polling showing Trump's approval among Catholic voters rebounded in April 2026 despite the feud intensifying — arguably the most important data point for understanding how the dispute has actually landed with the relevant public.",
-      },
-      {
-        title: "Quote Accuracy Issue",
-        body: `The response quotes Trump as saying to “stay in his lane” — but verified sources show Trump's actual language was to “get his act together as Pope, use Common Sense, stop catering to the Radical Left, and focus on being a Great Pope, not a Politician.” Paraphrasing quotes without flagging them as paraphrases misrepresents tone and substance.`,
-      },
-    ],
-    sources: [
-      { label: "whyy.org — Trump-Pope dispute, Catholics in Bucks County", url: "https://whyy.org/articles/trump-pope-dispute-catholics-bucks-county/" },
-      { label: "georgetown.edu — First American Pope", url: "https://www.georgetown.edu/news/what-it-means-for-the-first-american-to-be-chosen-as-pope/" },
-      { label: "war.gov — Operation Epic Fury", url: "https://www.war.gov/Spotlights/Operation-Epic-Fury/" },
-      { label: "americamagazine.org — Pope Leo on Iran war", url: "https://www.americamagazine.org/news/2026/04/10/pope-leo-war-iran-criticism/" },
-      { label: "usccb.org — Pope Leo calls for ceasefire", url: "https://www.usccb.org/news/2026/pope-leo-calls-ceasefire-middle-east-special-prayers-lebanon" },
-      { label: "livenowfox.com — Trump blasts Pope Leo XIV", url: "https://www.livenowfox.com/news/trump-blasts-pope-leo-xiv-truth-social-weak-crime-foreign-policy" },
-      { label: "cbsnews.com — How dispute escalated", url: "https://www.cbsnews.com/news/how-dispute-trump-pope-leo-escalated/" },
-      { label: "pbs.org — Trump says he doesn't owe Pope an apology", url: "https://www.pbs.org/newshour/politics/watch-trump-says-he-doesnt-owe-pope-leo-an-apology-after-attacking-him-for-comments-on-iran" },
-      { label: "wikipedia.org — 2026 US–Holy See rift", url: "https://en.wikipedia.org/wiki/2026_United_States%E2%80%93Holy_See_rift" },
-      { label: "ncregister.com — Trump-Pope Leo takeaways", url: "https://www.ncregister.com/commentaries/editorial-trump-pope-leo-takeaways" },
-      { label: "ncronline.org — Trump says he has right to disagree", url: "https://www.ncronline.org/news/trump-says-he-has-right-disagree-pope-leo-meeting-him-not-necessary" },
-    ],
-  },
-];
+let llmSummaryData = null;
+let llmSummaryLoading = false;
+
+const LLM_URLS = {
+  ChatGPT: "https://chatgpt.com",
+  Gemini: "https://gemini.google.com",
+  Claude: "https://claude.ai",
+};
+
+async function loadLLMData(query) {
+  if (!query) return;
+  llmSummaryLoading = true;
+  llmSummaryData = null;
+  renderLLM();
+  renderAISources();
+  try {
+    const res = await fetch(`/api/llm-summary?q=${encodeURIComponent(query)}`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || "LLM analysis failed.");
+    llmSummaryData = data;
+  } catch (err) {
+    llmSummaryData = { error: err.message };
+  } finally {
+    llmSummaryLoading = false;
+  }
+  renderLLM();
+  renderAISources();
+}
+
+function renderAISources() {
+  const container = document.getElementById("timeline-ai-sources");
+  if (!container) return;
+  container.innerHTML = "";
+  if (!llmSummaryData || !llmSummaryData.llms || !llmSummaryData.llms.length) return;
+
+  const label = document.createElement("div");
+  label.className = "ai-sources-label";
+  label.textContent = "AI Sources";
+  container.appendChild(label);
+
+  const cards = document.createElement("div");
+  cards.className = "ai-sources-cards";
+  llmSummaryData.llms.forEach((m) => {
+    const card = document.createElement("div");
+    card.className = "ai-source-card";
+    card.style.borderLeftColor = m.color;
+    card.innerHTML = `
+      <span class="ai-source-name">${m.name}</span>
+      <span class="ai-source-summary">${m.summary}</span>
+    `;
+    card.addEventListener("click", () => setView("llm"));
+    cards.appendChild(card);
+  });
+  container.appendChild(cards);
+}
+
 
 function renderLLM() {
   const wrap = document.getElementById("llm-cards");
+  const headline = document.getElementById("llm-headline");
+  if (headline) headline.textContent = currentQuery ? `"${currentQuery}"` : "";
+
   wrap.innerHTML = "";
-  llmData.forEach((m) => {
+
+  if (llmSummaryLoading) {
+    wrap.innerHTML = '<p class="llm-status">Analyzing…</p>';
+    return;
+  }
+  if (!currentQuery) {
+    wrap.innerHTML = '<p class="llm-status">Search for a story to see LLM analysis.</p>';
+    return;
+  }
+  if (!llmSummaryData) {
+    wrap.innerHTML = '<p class="llm-status">No analysis available.</p>';
+    return;
+  }
+  if (llmSummaryData.error) {
+    wrap.innerHTML = `<p class="llm-status llm-status-error">${llmSummaryData.error}</p>`;
+    return;
+  }
+
+  llmSummaryData.llms.forEach((m) => {
     const card = document.createElement("div");
     card.className = "llm-card collapsed";
     card.style.borderTopColor = m.color;
@@ -1295,9 +1268,14 @@ function renderLLM() {
       <li><a href="${s.url}" target="_blank" rel="noopener">${s.label}</a></li>
     `).join("");
 
+    const nameUrl = LLM_URLS[m.name];
+    const nameEl = nameUrl
+      ? `<a class="llm-name" href="${nameUrl}" target="_blank" rel="noopener">${m.name}</a>`
+      : `<span class="llm-name">${m.name}</span>`;
+
     card.innerHTML = `
       <div class="llm-card-header">
-        <a class="llm-name" href="${m.url}" target="_blank" rel="noopener">${m.name}</a>
+        ${nameEl}
         <span class="chevron">›</span>
       </div>
       <p class="llm-summary">${m.summary}</p>
@@ -1306,6 +1284,8 @@ function renderLLM() {
         <ol class="llm-bias-list">${biasItems}</ol>
         <div class="llm-section-label">Sources</div>
         <ul class="llm-sources-list">${sourceItems}</ul>
+        <button class="llm-raw-toggle" aria-expanded="false">Full Response <span class="llm-raw-chevron">›</span></button>
+        <div class="llm-raw-body" hidden></div>
       </div>
     `;
 
@@ -1313,6 +1293,21 @@ function renderLLM() {
       card.classList.toggle("collapsed");
       card.querySelector(".chevron").textContent = card.classList.contains("collapsed") ? "›" : "⌄";
     });
+
+    const rawToggle = card.querySelector(".llm-raw-toggle");
+    const rawBody = card.querySelector(".llm-raw-body");
+    if (m.raw_response) {
+      rawBody.innerHTML = marked.parse(m.raw_response);
+      rawToggle.addEventListener("click", () => {
+        const open = rawBody.hidden;
+        rawBody.hidden = !open;
+        rawToggle.setAttribute("aria-expanded", open);
+        rawToggle.querySelector(".llm-raw-chevron").textContent = open ? "⌄" : "›";
+      });
+    } else {
+      rawToggle.hidden = true;
+    }
+
     wrap.appendChild(card);
   });
 }
@@ -1820,7 +1815,7 @@ async function init() {
   document.getElementById("gate-signin-btn").addEventListener("click", () => handleGateAuth("signin"));
   document.getElementById("gate-signup-btn").addEventListener("click", () => handleGateAuth("signup"));
 
-  renderLLM();
+  renderLLM(); // initial empty state
 
   const savedSearch = sessionStorage.getItem("lastSearch");
   if (savedSearch) {
@@ -1828,6 +1823,7 @@ async function init() {
       const { query, results } = JSON.parse(savedSearch);
       currentQuery = query;
       landingEl.classList.add("hidden");
+      loadLLMData(query); // fire in parallel, no await
       await loadAndRender(query, results);
       setStoryHeadline(query);
     } catch (_) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
 </head>
 <body>
 
@@ -146,6 +147,7 @@
           <!-- Timeline content -->
           <div class="timeline-content">
             <h2 class="story-headline" id="timeline-headline"></h2>
+            <div id="timeline-ai-sources" class="timeline-ai-sources"></div>
             <div class="timeline-columns" id="timeline-columns">
               <!-- Columns injected by JS -->
             </div>
@@ -190,7 +192,7 @@
       <!-- LLM VIEW -->
       <section id="view-llm" class="view">
         <h2 class="sub-headline">Analysis on LLM's report on:</h2>
-        <h3 class="story-headline">"Dispute Between Pope Leo &amp; Trump"</h3>
+        <h3 class="story-headline" id="llm-headline"></h3>
         <div class="llm-cards" id="llm-cards">
           <!-- Cards injected by JS -->
         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1222,7 +1222,65 @@ body {
   line-height: 1.5;
 }
 
+/* ── AI Sources row (timeline) ────────────────────────── */
+.timeline-ai-sources {
+  padding: 16px 8px 0;
+}
+
+.ai-sources-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--slate-400);
+  margin-bottom: 8px;
+}
+
+.ai-sources-cards {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ai-source-card {
+  border-left: 3px solid #10a37f;
+  background: var(--slate-50);
+  border-radius: 8px;
+  padding: 10px 14px;
+  max-width: 280px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.ai-source-card:hover { background: var(--slate-100); }
+
+.ai-source-name {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--navy-800);
+  margin-bottom: 4px;
+}
+
+.ai-source-summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 12px;
+  color: var(--slate-600);
+  line-height: 1.45;
+}
+
 /* ── LLM ──────────────────────────────────────────────── */
+.llm-status {
+  padding: 24px 0;
+  color: var(--slate-400);
+  font-size: 14px;
+}
+
+.llm-status-error { color: #ef4444; }
+
 .llm-cards {
   display: flex;
   flex-direction: column;
@@ -1307,6 +1365,49 @@ body {
 .llm-sources-list li { font-size: 12px; line-height: 1.4; }
 .llm-sources-list a { color: var(--accent); text-decoration: none; word-break: break-all; }
 .llm-sources-list a:hover { text-decoration: underline; }
+
+.llm-raw-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 18px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--slate-400);
+}
+.llm-raw-toggle:hover { color: var(--slate-600); }
+.llm-raw-chevron { font-style: normal; }
+
+.llm-raw-body {
+  margin-top: 12px;
+  padding: 16px;
+  background: var(--slate-50);
+  border: 1px solid var(--slate-200);
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--slate-600);
+  overflow-x: auto;
+}
+.llm-raw-body h1,.llm-raw-body h2,.llm-raw-body h3 {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--navy-900);
+  margin: 14px 0 6px;
+}
+.llm-raw-body h1:first-child,.llm-raw-body h2:first-child,.llm-raw-body h3:first-child { margin-top: 0; }
+.llm-raw-body p { margin: 0 0 10px; }
+.llm-raw-body ul,.llm-raw-body ol { padding-left: 18px; margin: 0 0 10px; }
+.llm-raw-body li { margin-bottom: 4px; }
+.llm-raw-body a { color: var(--accent); text-decoration: none; word-break: break-all; }
+.llm-raw-body a:hover { text-decoration: underline; }
+.llm-raw-body strong { font-weight: 600; color: var(--navy-900); }
 
 /* ── MODAL ────────────────────────────────────────────── */
 .modal-overlay {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "scikit-learn (>=1.6.0,<2.0.0)",
     "scipy (>=1.15.0,<2.0.0)",
     "supabase>=2.30.0",
+    "anthropic>=0.105.2",
+    "google-genai>=2.7.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.105.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -591,6 +610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -620,8 +648,10 @@ name = "final-project-26"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "bs4" },
     { name = "fastapi" },
+    { name = "google-genai" },
     { name = "hdbscan" },
     { name = "justext" },
     { name = "lxml" },
@@ -647,8 +677,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.105.2" },
     { name = "bs4", specifier = ">=0.0.2" },
     { name = "fastapi", specifier = ">=0.136.1" },
+    { name = "google-genai", specifier = ">=2.7.0" },
     { name = "hdbscan", specifier = ">=0.8.40,<0.9.0" },
     { name = "justext", specifier = ">=3.0.2" },
     { name = "lxml", specifier = ">=6.1.0" },
@@ -720,6 +752,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/7b/6eb3b3d545b6bb4c374acba1ccf91b0f33b605e551536a6243cfcef2f07f/google_genai-2.7.0.tar.gz", hash = "sha256:3c6f32f5ced9877ededd1b384b5e5b7f09c20046ec3390b662b16d8cd1882ac5", size = 555853, upload-time = "2026-05-28T15:39:24.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/7a8be39e9d698e80e9db796514efbc6083dbd787bdb9a101e8ba47248e5e/google_genai-2.7.0-py3-none-any.whl", hash = "sha256:21cac381e09a869151706aba797b6a4f96cfe92c484e13204d092caee7ff11cb", size = 822545, upload-time = "2026-05-28T15:39:22.907Z" },
 ]
 
 [[package]]
@@ -1995,6 +2066,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]

--- a/webscraper/README.md
+++ b/webscraper/README.md
@@ -81,10 +81,14 @@ python scrape.py
 Orchestrates a full refresh across all APIs and merges results into a single file.
 
 **CLI options:**
---api : Which API to fetch from: newsapi, nyt, current, or all (default: all)
+
+| Option    | Default          | Description                                          |
+|-----------|------------------|------------------------------------------------------|
+| `--query` | `"Trump Pope Leo"` | Keyword search string passed to all APIs           |
+| `--api`   | `all`            | Which API to fetch from: `newsapi`, `nyt`, `current`, or `all` |
 
 **What it does:**
-1. Calls scrape.py as a subprocess for each API (newsapi, nyt, current) with --overwrite, passing the shared QUERY, START, and a dynamically computed END (current UTC time)
+1. Calls scrape.py as a subprocess for each API (newsapi, nyt, current) with --overwrite, passing the `--query` argument, START, and a dynamically computed END (current UTC time)
 2. If a scrape fails (e.g. rate limit), it logs the error and continues with the remaining APIs
 3. Merges all data/*_articles.json files, deduplicates by URL, sorts by date descending, and writes the combined result to data/articles.json
    


### PR DESCRIPTION
## Summary
- Replaces the hardcoded LLM Analysis view with a live pipeline that queries ChatGPT (gpt-5.4-mini), Gemini (gemini-3.5-flash), and Claude (claude-haiku-4-5) in parallel for each search topic
- Each LLM uses web search grounding (step 1) followed by a meta-analysis extraction call using the same model (step 2), returning structured bias findings and cited sources
- Adds a pinned AI Sources row above the timeline with a card per LLM; clicking navigates to the LLM Analysis view
- Adds a Full Response sub-toggle inside each LLM card, rendering the raw web-grounded response as formatted markdown via marked.js
- Results are cached to data/llm_summaries/ with a 24-hour TTL; the LLM pipeline fires in parallel with the article search on every query
- Updates all READMEs to reflect the new backend files, API endpoints, env vars, and frontend behavior

## Necessary Env Changes
Set OPENAI_API_KEY, ANTHROPIC_API_KEY, and GOOGLE_API_KEY.