### PR TITLE
Add semantic story clustering

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -125,6 +125,21 @@ Generate a short AI overview of one source's loaded articles. Requires `OPENAI_A
 }
 ```
 
+### `POST /api/semantic-clusters`
+
+Group loaded articles by semantic similarity using OpenAI embeddings. Requires `OPENAI_API_KEY`.
+
+```json
+{
+  "articles": [
+    {
+      "title": "...",
+      "description": "..."
+    }
+  ]
+}
+```
+
 ---
 
 ## Environment variables
@@ -134,7 +149,7 @@ Generate a short AI overview of one source's loaded articles. Requires `OPENAI_A
 | ----------- | ------------------------ | ------------------------- |
 | `REDIS_URL` | `redis://localhost:6379` | Redis connection string   |
 | `DATA_PATH` | `data/articles.json`     | Path to article JSON file |
-| `OPENAI_API_KEY` | — | OpenAI API key used for article comparisons and channel summaries |
+| `OPENAI_API_KEY` | — | OpenAI API key used for article comparisons, channel summaries, and semantic clustering |
 
 
 Add both to `.env` (see `.env.example`). For Vercel, provision Upstash Redis from the Marketplace and set `REDIS_URL` in project settings.

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from users import router as users_router
 from compare import router as compare_router
 from bias import router as bias_router
 from channel_summary import router as channel_summary_router
+from semantic_clusters import router as semantic_clusters_router
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(HERE, "..", "data")
@@ -37,6 +38,7 @@ app.include_router(users_router)
 app.include_router(compare_router)
 app.include_router(bias_router)
 app.include_router(channel_summary_router)
+app.include_router(semantic_clusters_router)
 
 @app.get("/api/ready")
 def api_ready():

--- a/backend/semantic_clusters.py
+++ b/backend/semantic_clusters.py
@@ -1,0 +1,100 @@
+import hashlib
+import json
+import math
+import os
+
+from fastapi import APIRouter, HTTPException
+from openai import OpenAI
+from pydantic import BaseModel
+
+router = APIRouter()
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+SIMILARITY_THRESHOLD = 0.70
+MAX_ARTICLES = 50
+_cluster_cache: dict[str, list[list[int]]] = {}
+
+
+class ClusterArticle(BaseModel):
+    title: str
+    description: str | None = ""
+
+
+class SemanticClusterRequest(BaseModel):
+    articles: list[ClusterArticle]
+
+
+def _article_text(article: ClusterArticle) -> str:
+    text = f"{article.title}. {article.description or ''}".strip()
+    return text[:6000] or "Untitled article"
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    dot_product = sum(x * y for x, y in zip(a, b))
+    a_magnitude = math.sqrt(sum(x * x for x in a))
+    b_magnitude = math.sqrt(sum(y * y for y in b))
+    return dot_product / (a_magnitude * b_magnitude) if a_magnitude and b_magnitude else 0
+
+
+def _cluster_embeddings(embeddings: list[list[float]]) -> list[list[int]]:
+    clusters = [[article_index] for article_index in range(len(embeddings))]
+
+    def average_similarity(a: list[int], b: list[int]) -> float:
+        scores = [
+            _cosine_similarity(embeddings[a_index], embeddings[b_index])
+            for a_index in a
+            for b_index in b
+        ]
+        return sum(scores) / len(scores)
+
+    while len(clusters) > 1:
+        best_pair = None
+        best_score = 0.0
+        for a_index in range(len(clusters)):
+            for b_index in range(a_index + 1, len(clusters)):
+                score = average_similarity(clusters[a_index], clusters[b_index])
+                if score > best_score:
+                    best_pair = (a_index, b_index)
+                    best_score = score
+
+        if best_pair is None or best_score < SIMILARITY_THRESHOLD:
+            break
+
+        a_index, b_index = best_pair
+        clusters[a_index].extend(clusters[b_index])
+        clusters.pop(b_index)
+
+    return clusters
+
+
+def _cache_key(articles: list[ClusterArticle]) -> str:
+    payload = [{"title": article.title, "description": article.description} for article in articles]
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+@router.post("/api/semantic-clusters")
+async def semantic_clusters(req: SemanticClusterRequest):
+    if not req.articles:
+        return {"clusters": []}
+    if len(req.articles) > MAX_ARTICLES:
+        raise HTTPException(status_code=400, detail=f"Cluster up to {MAX_ARTICLES} articles.")
+
+    key = _cache_key(req.articles)
+    if key in _cluster_cache:
+        return {"clusters": _cluster_cache[key], "cached": True}
+
+    try:
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.embeddings.create(
+            model=EMBEDDING_MODEL,
+            input=[_article_text(article) for article in req.articles],
+            encoding_format="float",
+        )
+        embeddings = [item.embedding for item in response.data]
+        clusters = _cluster_embeddings(embeddings)
+        if len(_cluster_cache) >= 32:
+            _cluster_cache.pop(next(iter(_cluster_cache)))
+        _cluster_cache[key] = clusters
+        return {"clusters": clusters, "cached": False}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -607,6 +607,63 @@ function toClusterData(articles) {
   return storyClusters;
 }
 
+function toSemanticClusterData(articles, clusters) {
+  const docFreq = buildClusterDocumentFrequency(articles);
+  const grouped = clusters.map((indexes, index) => {
+    const clusterArticles = indexes.map(articleIndex => articles[articleIndex]).filter(Boolean);
+    return {
+      id: index + 1,
+      label: labelCluster(clusterArticles, docFreq, articles.length),
+      articles: clusterArticles,
+      sourceCount: new Set(clusterArticles.map(article => article.source)).size,
+    };
+  }).filter(cluster => cluster.articles.length)
+    .sort((a, b) => b.articles.length - a.articles.length || b.sourceCount - a.sourceCount);
+
+  const storyClusters = grouped.filter(cluster => cluster.articles.length > 1);
+  const singletons = grouped.filter(cluster => cluster.articles.length === 1);
+  if (singletons.length) {
+    storyClusters.push({
+      id: "other",
+      label: "Other Coverage",
+      articles: singletons.flatMap(cluster => cluster.articles),
+      sourceCount: new Set(singletons.flatMap(cluster => cluster.articles.map(article => article.source))).size,
+    });
+  }
+  return storyClusters;
+}
+
+async function loadSemanticClusters(articles) {
+  const status = document.getElementById("cluster-status");
+  if (!articles.length) {
+    status.textContent = "";
+    return;
+  }
+
+  status.textContent = "Improving groups with semantic analysis...";
+  try {
+    const response = await fetch("/api/semantic-clusters", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        articles: articles.map(article => ({
+          title: article.title,
+          description: article.description || "",
+        })),
+      }),
+    });
+    if (!response.ok) throw new Error("Semantic clustering is unavailable.");
+    const data = await response.json();
+    if (!Array.isArray(data.clusters)) throw new Error("Semantic clustering returned an invalid response.");
+    clusterData = toSemanticClusterData(articles, data.clusters);
+    status.textContent = "Grouped by semantic similarity";
+    if (currentView === "clusters") renderStoryClusters();
+  } catch (error) {
+    console.error("Could not load semantic clusters:", error);
+    status.textContent = "Showing keyword-based groups";
+  }
+}
+
 // ---------- Dynamic UI builders ----------
 
 function buildSourceFilters(sources) {
@@ -1768,6 +1825,7 @@ async function loadAndRender(query, prefetchedArticles) {
 
     renderTimeline();
     if (currentView === "clusters") renderStoryClusters();
+    loadSemanticClusters(normalized);
   } catch (err) {
     console.error("Could not load articles:", err);
     timelineColumnsEl.innerHTML =

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -176,6 +176,7 @@
       <section id="view-clusters" class="view">
         <h2 class="sub-headline">Story Clusters</h2>
         <h3 class="story-headline story-headline-dynamic"></h3>
+        <div class="cluster-status" id="cluster-status"></div>
         <div class="cluster-list" id="cluster-list">
           <!-- Clusters injected by JS -->
         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1090,6 +1090,14 @@ body {
   max-width: 980px;
 }
 
+.cluster-status {
+  min-height: 18px;
+  margin: -4px 0 10px;
+  color: var(--slate-400);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .story-cluster {
   background: var(--white);
   border: 1px solid var(--slate-200);


### PR DESCRIPTION
Experimental backend semantic clustering implementation for Story Clusters.

- Adds a `/api/semantic-clusters` backend endpoint.
- Generates article embeddings using OpenAI `text-embedding-3-small`.
- Groups articles using agglomerative hierarchical clustering with cosine similarity.
- Keeps the existing frontend keyword-based clustering as a fallback.
- Caches repeat semantic-clustering requests.