### PR TITLE
Fix timeline source filter consistency and UX

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -436,8 +436,7 @@ function toTimelineData(articles) {
             // coverageBonus is equal for all articles on the same day,
             // so this effectively sorts by credibility tier, then by time
             return scoreDiff || new Date(a.isoTime) - new Date(b.isoTime);
-          })
-          .slice(0, TOP_N_PER_DATE),
+          }),
       };
     });
 }
@@ -656,12 +655,20 @@ function buildSourceFilters(sources) {
   toggleRow.appendChild(noneBtn);
   container.appendChild(toggleRow);
 
+  const details = document.createElement("details");
+  details.className = "source-list-collapse";
+  const summary = document.createElement("summary");
+  summary.className = "source-list-summary";
+  summary.textContent = `${sources.length} sources`;
+  details.appendChild(summary);
+
   sources.forEach((src) => {
     const label = document.createElement("label");
     label.className = "check";
     label.innerHTML = `<input type="checkbox" data-src="${src}" checked /> <span class="dot" style="background:${sourceColor(src)}"></span> ${src}`;
-    container.appendChild(label);
+    details.appendChild(label);
   });
+  container.appendChild(details);
 }
 
 function buildChannelCards(sources) {
@@ -785,7 +792,7 @@ function getFilteredTimelineData() {
           }
         }
         return true;
-      }),
+      }).slice(0, TOP_N_PER_DATE),
     }))
     .filter((group) => group.articles.length > 0);
 }
@@ -1779,7 +1786,7 @@ async function loadAndRender(query, prefetchedArticles) {
     clusterData = toClusterData(normalized);
     channelSummaryCache.clear();
 
-    const sources = Object.keys(channelData).sort();
+    const sources = [...new Set(timelineData.flatMap(group => group.articles.map(a => a.src)))].sort();
     assignSourceColors(sources);
     buildSourceFilters(sources);
     buildChannelCards(sources);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -693,6 +693,35 @@ body {
 
 .source-toggle-btn:hover { background: var(--slate-100); }
 
+.source-list-collapse {
+  margin-top: 6px;
+}
+
+.source-list-summary {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--slate-400);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.source-list-summary::-webkit-details-marker { display: none; }
+
+.source-list-summary::before {
+  content: "▶";
+  font-size: 9px;
+  transition: transform 0.15s;
+}
+
+.source-list-collapse[open] .source-list-summary::before {
+  transform: rotate(90deg);
+}
+
 .check {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
The source filter checkboxes were populated from channelData, which holds all articles unsliced, while the timeline itself
  only showed the top 5 articles per date (sliced inside toTimelineData). This meant sources could appear in the filter
  with no visible articles in the timeline.

## Changes:
  - Moved TOP_N_PER_DATE slice out of toTimelineData and into getFilteredTimelineData, so the cap applies after user filters
  run rather than before. This also means deselecting sources opens up slots for lower-ranked articles from remaining
  sources.
  - Source list for the filter is now derived from timelineData instead of channelData, making all three data stores
  (timelineData, channelData, clusterData) consistent — all hold the full unsliced article set.
  - Wrapped the source checkbox list in a <details>/<summary> element so it collapses by default, reducing sidebar clutter.
  Shows source count in the summary; arrow rotates on expand.